### PR TITLE
Minor clarification to the Charter

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -189,8 +189,8 @@
       specifications for convenience.  However, all Specifications being worked
       on must be clearly indicated on the CG Web page.
       Example of what the specification could look like:
-      <a href="http://w3c.github.io/nfc/index.html">
-      http://w3c.github.io/nfc/index.html</a>.
+      <a href="http://w3c.github.io/web-nfc/">
+      http://w3c.github.io/web-nfc/</a>.
     </p>
   </section>
   <section><h3>Community Group Reports that are not Specifications </h3>


### PR DESCRIPTION
This PR updates the link in the Deliverables section of the Charter [1] to point to the latest Web NFC API [2] spec that reflects the direction of the Web NFC Community Group [3].

[1] https://w3c.github.io/web-nfc/charter/
[2] http://w3c.github.io/web-nfc/
[3] https://www.w3.org/community/web-nfc/
