### PR TITLE
update charter with newer template

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -291,92 +291,150 @@
   </dl>
 </section>
 
-<section><h1>Community and Business Group Process</h1>
-  <p>
-    Terms of in this charter that conflict with those of the Community and
-    Business Group Process are void.
-  </p>
-  <section><h2>Work Limited to Charter Scope</h2>
-    <p>
-      The group will not publish Community Group Reports that are Specifications
-      on topics other than those listed under "Community Group Reports that are
-      Specifications" above. See below for how to modify the charter. The CLA
-      applies to these Community Group Reports.
-    </p>
+<section>
+    <h2>Community and Business Group Process</h2>
+    <p>Terms of in this charter that conflict with those of the Community and
+    Business Group Process are void.</p>
   </section>
-  <section><h2>Contribution Mechanics</h2>
-    <p>
-      For these Reports, Community Group participants agree to send
-      contributions to either the group “contrib” list or to the general group
-      list, with subject line starting "“[short-name-for spec]".
-      When meeting discussion includes contributions, contributors are
-      expected to record those contributions explicitly on the mailing list as
-      described.
-    </p>
+  
+  <section>
+    <h2>Work Limited to Charter Scope</h2>
+    <p>The group will not publish Community Group Reports that are
+    Specifications other than those described in "Community
+    Group Reports that are Specifications" above. See below for how to modify
+    the charter.</p>
   </section>
-  <section><h2>Chair Selection</h2>
-    <p>
-      Participants in this group choose their Chair(s) and can replace their
-      Chair(s) at any time using whatever means they prefer. However, if 5
-      participants — no two from the same organization — call for an election,
-      the group must use the following process to replace any current Chair(s)
-      with a new Chair, consulting the Community Development Lead on election
-      operations (e.g., voting infrastructure and using RFC 2777). Participants
-      announce their candidacies. Participants have 14 days to announce their
-      candidacies, but this period ends as soon as all participants have
-      announced their intentions. If there is only one candidate, that person
-      becomes the Chair. If there are two or more candidates, there is a vote.
-      Otherwise, nothing changes. Participants vote. Participants have 21 days
-      to vote for a single candidate, but this period ends as soon as all
-      participants have voted. The individual who receives the most votes — no
-      two from the same organization — is elected chair. In case of a tie,
-      RFC2777 is used to break the tie. An elected Chair may appoint co-Chairs.
-      Participants dissatisfied with the outcome of an election may ask the
-      Community Development Lead to intervene. The Community Development Lead,
-      after evaluating the election, may take any action including no action.
-    </p>
+  
+  <section>
+    <h2>Contribution Mechanics</h2>
+    
+	  <section>
+	    <h3>Who can make Contributions</h3>
+	
+	    <p>Contributions can only be made by Community Group Participants (so all
+	    Contributors have agreed to the CLA). Particular care must be taken to
+	    ensure Contributions of content that is implementable comes from
+	    Community Group participants.</p>
+	  </section>
+	
+    <section>
+	    <h3>How Contributions are made</h3>
+	
+	    <p>Community Group Participants agree that all Contributions will be
+	    documented in pull requests and commits for a particular document in
+	    the group's GitHub repository.</p>
+	    
+	   <section>
+	      <h4>Specifications</h4>
+	
+	      <p>For Contributions to Specifications, if someone other than the
+	      Contributor makes the pull request, the pull request SHOULD indicate who
+	      the request was made on behalf of and SHOULD provide a reference to the relevant
+	      archived GitHub Issue or group mail thread where practical. The information
+	      SHOULD be specific enough to easily determine who the Contributors were
+	      and that the intention was to change a particular Specification.
+	      In the commit, if practical, this information SHOULD be in the form 
+	      {Contributors: ["githubusername1","githubusername2"]}.</p>
+	    </section>
+	    
+      <section>
+        <h4>Software</h4>
+        <p>For software, the GitHub Contributing and License files describes 
+        how to Contribute and the license under which Contributions are made.</p>
+      </section>
+    </section>
   </section>
-  <section><h2>Decision Process</h2>
-    <p>
-      This group will seek to make decisions when there is consensus. When the
-      group discusses  an issue on the mailing list and there is a call from the
-      group for assessing consensus, after due consideration of different
-      opinions, the Chair should record a decision and any objections.
-      Participants may call for an online vote if they feel the Chair has not
-      accurately determined the consensus of the group or if the Chair refuses
-      to assess consensus. The call for a vote must specify the duration of the
-      vote which must be at least 7 days and should be no more than 14 days.
-      The Chair must start the vote within 7 days of the request. The decision
-      will be based on the majority of the ballots cast. It is the Chair’s
-      responsibility to ensure that the decision process is fair, respects the
-      consensus of the CG, and does not unreasonably favor or discriminate
-      against any group participant or their employer.
-    </p>
+  
+  <section>
+    <h2>Decision Process</h2>
+    <p>This group will seek to make decisions when there is consensus. When
+    the group discusses an issue on the mailing or Issues list and there is a
+    call from the group for assessing consensus, after due consideration of
+    different opinions, the Chair should record a decision and any
+    objections.</p>
+    
+    <p>A common way to determine consensus for important decisions is to
+    conduct a Call for Consenus (CfC) where the Chair puts a proposal to the
+    group on the public mail list and asks for feedback from the Participants
+    within some period of time that is at least 7 days. Not responding
+    indicates going along with the proposal. Direct feedback is encouraged,
+    especially to weigh the degree of consensus when there is dissent.</p>
+    
+    <p>Participants MAY call for an online vote if they feel the Chair has
+    not accurately determined the consensus of the group or if the Chair
+    refuses to assess consensus. This should be a rare event, only where the
+    usual, less formal means of making decisions are not accepted. At least 5
+    Participants, no two from the same organization (or 50% of the
+    organizations and individuals, whichever is smaller), MUST agree with the
+    call for a formal vote. The call for a vote MUST specify the duration of
+    the vote which MUST be at least 7 days and should be no more than 14
+    days. The Chair MUST start the vote within 7 days of the request, or
+    group members MAY start it themselves. The decision will be based on the
+    majority of the ballots cast. It is the Chair's responsibility to ensure
+    that the decision process is fair, respects the consensus of the CG, and
+    does not unreasonably favor or discriminate against any group participant
+    or their employer.</p>
   </section>
-  <section><h2>Transparency</h2>
-    <p>
-      The group will conduct all of its technical work on its public mailing
-      list. Any decisions reached at any meeting are tentative. Any group
-      participant may object to a decision reached at an online meeting within
-      7 days of publication of the decision on the mail list. That decision must
-      then be confirmed on the mail list by the Decision Process above.
-    </p>
+  
+  <section>
+    <h2>Transparency</h2>
+    <p>The group will conduct all of its technical work on its The group will
+    conduct all of its technical work in public.</p>
+    
+    <p>Discussions MAY take place on the group's public mailing list. Other
+    discussions MAY take place using Issues in the group's GitHub repository.
+    For convenience, GitHub issues and pull requests will be archived to the
+    group's contrib list. Other contributions MAY be directly posted to the
+    contrib list.</p>
+    
+    <p>Meetings MAY be restricted to Community Group participants, but a public
+    summary or minutes MUST be posted to the group's public mail list.</p>
+    <p>Any decisions reached at any meeting are tentative. Any group
+    participant may object to a decision reached at a meeting within 7 days
+    of publication of the decision on the mail list. That decision must then be
+    confirmed on the mail list by the Decision Process above.</p>
   </section>
-  <section><h2>Amendments to this Charter</h2>
-    <p>
-      The group can decide to work on a proposed amended charter, editing the
-      text using the Decision Process described above. The decision on whether
-      to adopt the amended charter is made by conducting a 30-day vote on the
-      proposed new charter. The new charter, if approved, takes effect on either
-      the proposed date in the charter itself, or 7 days after the result of
-      the election is announced, whichever is later. A new charter must receive
-      2/3 of the votes cast in the approval vote to pass. The group may make
-      simple corrections to the charter such as deliverable dates by the
-      simpler group decision process rather than this charter amendment process.
-      The group will use the amendment process for any substantive changes to
-      the goals, scope, deliverables, decision process or rules for amending
-      the charter.
-    </p>
+  
+  <section>
+    <h2>Chair Selection</h2>
+    <p>Participants in this group choose their Chair(s) and can replace their
+    Chair(s) at any time using whatever means they prefer.</p>
+    <p>The following process is used if the less formal process above is not
+    acceeptable to group members. If 5 participants, no two from the same
+    organization, (or 50% of the organizations and individuals, whichever is
+    smaller) call for an election, the group must use the following process
+    to replace any current Chair(s) with a new Chair, consulting the
+    Community Development Lead on election operations (e.g., voting
+    infrastructure and using RFC 2777). Participants announce their
+    candidacies. Participants have 14 days to announce their candidacies, but
+    this period ends as soon as all participants have announced their
+    intentions. If there is only one candidate, that person becomes the
+    Chair. If there are two or more candidates, there is a vote. Otherwise,
+    nothing changes. Participants vote. Participants have 21 days to vote for
+    a single candidate, but this period ends as soon as all participants have
+    voted. The individual who receives the most votes —no two from the same
+    organization— is elected chair. In case of a tie, RFC2777 is used to
+    break the tie. An elected Chair may appoint co-Chairs. Participants
+    dissatisfied with the outcome of an election may ask the Community
+    Development Lead to intervene. The Community Development Lead, after
+    evaluating the election, may take any action including no action.</p>
   </section>
+  
+  <section>
+    <h2>Amendments to this Charter</h2>
+    <p>The group MAY decide to work on a proposed amended charter, editing
+    the text using the Decision Process described above. The decision on
+    whether to adopt the amended charter is made by conducting a 30-day vote
+    on the proposed new charter. The new charter, if approved, takes effect
+    on either the proposed date in the charter itself, or 7 days after the
+    result of the election is announced, whichever is later. A new charter
+    must receive 2/3 of the votes cast in the approval vote to pass. The
+    group may make simple corrections to the charter such as deliverable
+    dates by the simpler group decision process rather than this charter
+    amendment process. The group will use the amendment process for any
+    substantive changes to the goals, scope, deliverables, decision process
+    or rules for amending the charter.</p>
+  </section>
+  
 </body>
 </html>


### PR DESCRIPTION
changes have been made to the charter template from feedback from bluetooth cg and AC discussions.  For instance, it makes it clearer that CGs usually do things by whatever informal process they want.  The charter provides fallbacks for when there is disagreement about whether the result was fair.
