### PR TITLE
charter - change date and fix errorl

### DIFF
--- a/charter/index.html
+++ b/charter/index.html
@@ -32,7 +32,7 @@
     <li>This Charter: <a href="https://w3c.github.io/web-nfc/charter/">
     http://w3c.github.io/web-nfc/charter/</a></li>
     <li>Start Date: 2015-03-12</li>
-    <li>Last Modified: 2015-03-12</li>
+    <li>Last Modified: 2015-04-06</li>
   </ul>
 </section>
 
@@ -378,8 +378,7 @@
   
   <section>
     <h2>Transparency</h2>
-    <p>The group will conduct all of its technical work on its The group will
-    conduct all of its technical work in public.</p>
+    <p>The group will conduct all of its technical work in public.</p>
     
     <p>Discussions MAY take place on the group's public mailing list. Other
     discussions MAY take place using Issues in the group's GitHub repository.

--- a/charter/index.html
+++ b/charter/index.html
@@ -399,7 +399,7 @@
     <p>Participants in this group choose their Chair(s) and can replace their
     Chair(s) at any time using whatever means they prefer.</p>
     <p>The following process is used if the less formal process above is not
-    acceeptable to group members. If 5 participants, no two from the same
+    acceptable to group members. If 5 participants, no two from the same
     organization, (or 50% of the organizations and individuals, whichever is
     smaller) call for an election, the group must use the following process
     to replace any current Chair(s) with a new Chair, consulting the


### PR DESCRIPTION
updated the last modified date and corrected the first sentence in transparency.  the problem with the older version of that sentence is is said all technical work would take place on the public mail list -- that was from a version of the template where GitHub wasn't being used.
