### PR TITLE
Added alternative implementation details to Web NFC

### DIFF
--- a/security-privacy.html
+++ b/security-privacy.html
@@ -224,13 +224,13 @@
     </p>
     <dl title="dictionary NfcAccess" class="idl">
       <dt>DOMString scope</dt>
-      <dt>boolean write</dt>
+      <dt>boolean canWrite</dt>
     </dl>
     <p>
       The <dfn id="widl-NfcAccess-scope">scope</dfn> property is a string
       pattern for matching the URL's that are explicitly allowed to access
       the data, for instance <br>
-      <code>{ "scope": "https://mydomain.com", "write": "true"}</code>. <br>
+      <code>{ "scope": "https://mydomain.com", "canWrite": "true"}</code>. <br>
       Scopes which don't
       <a href="http://w3c.github.io/web-nfc/#the-within-scope-algorithm">match</a> this are not permitted to access the data.
       If the whitelist is empty, then the platform default policy applies,
@@ -239,7 +239,7 @@
       <a href="http://w3c.github.io/web-nfc/#the-within-scope-algorithm">match</a> the origin of the page which wrote the existing data.
     </p>
     <p>
-      When the <dfn id="widl-NfcAccess-write">write</dfn> property is
+      When the <dfn id="widl-NfcAccess-canWrite">canWrite</dfn> property is
       <code>true</code>, then the URL's matching <code><var>scope</var></code>
       are permitted to write (in fact, update) the data, otherwise they are only permitted to read it.
     </p>
@@ -342,8 +342,8 @@
                       "id": "http://w3.org/web-nfc/access/0/scope",
                       "type": "string"
                     },
-                    "write": {
-                      "id": "http://w3.org/web-nfc/access/0/write",
+                    "canWrite": {
+                      "id": "http://w3.org/web-nfc/access/0/canWrite",
                       "type": "boolean"
                     }
                   }

--- a/security-privacy.html
+++ b/security-privacy.html
@@ -313,6 +313,11 @@
         </li>
       </ul>
     </p>
+    <p class="note">
+      The encoded JSON format for Web NFC data and metadata is useful for
+      abstracting away NFC Forum types, and for supporting implementations where
+      an NDEF message contains only one NDEF record.
+    </p>
   </section>
 </section>
 

--- a/security-privacy.html
+++ b/security-privacy.html
@@ -194,11 +194,11 @@
     In order to support security policies concerning the Web NFC API, certain
     mechanisms need to be supported in all the implementations, such as:
     <ul>
-      <li>a mechanism for telling apart “Web NFC tags” from generic NFC tags
-        </li>
-      <li>a mechanism for white-listing URL's that can read, or write a certain
+      <li>an identification mechanism for telling apart “Web NFC tags” from
+        generic NFC tags</li>
+      <li>a mechanism for whitelisting URL's that can read, or write a certain
         Web NFC tag</li>
-      <li>a mechanism for black-listing URI's that can read, or write a certain
+      <li>a mechanism for blacklisting URI's that can read, or write a certain
         Web NFC tag.</li>
     </ul>
   </p>
@@ -207,90 +207,112 @@
 <section class="informative"> <h2>Implementation details</h2>
   <p>
     This section contains discussion of implementation possibilities of security
-    related mechanisms.
+    related mechanisms. The following implementation alternatives are possible:
+    <ul>
+      <li>
+        Use additional NDEF records in an NDEF message containing
+        Web NFC specific metadata, such as identification, whitelists and
+        blacklists.
+      </li>
+        Use a specific Web NFC record format and encode the Web NFC specific
+        metadata into that.
+      </li>
+    </ul>
   </p>
-  <section> <h3>Web NFC tags</h3>
+  <section> <h3>Web NFC using additional NDEF records for metadata</h3>
     <p>
-      For making tags that can be read and written by the Web NFC API, and for
-      making sure that web pages cannot access generic NFC tags, the following
-      are possible:
+      A typical Web NFC NDEF message will contain the following
+      NDEF records:
       <ul>
-        <li>Use the NDEF record <code>id</code> field in order to store the
-          origin of the page creating the record, which is also by default
-          allowed to modify the tag.</li>
-        <li>Use additional special NDEF records in each Web NFC tag, which are
-          hidden by the implementation. This solution depends on support for
-          writing multiple NDEF records per NDEF message.</li>
-        <li>Use additional data encoded into the NFC payload in a way which is
-          specific to Web NFC API. This solution is not desirable.</li>
+        <li>Normal NDEF records carrying data.</li>
+        <li>
+          An additional NDEF record for identification.
+          The preferred type of this NDEF record is NFC Forum External Type
+          (TNF=0x04), with the External Type field set to e.g.
+          <code>urn:nfc:ext:w3.org:web-nfc-id</code>.
+        </li>
+        <li>
+          An optional additional NDEF record for whitelisting for
+          reading.
+          The preferred type of this NDEF record is NFC Forum External Type
+          (TNF=0x04), with the External Type field set to
+          <code>urn:nfc:ext:w3.org:web-nfc-wl-read</code>.
+          The payload is a string list of URL's, delimited by white space.
+        </li>
+        <li>
+          An optional additional NDEF record for whitelisting for
+          writing.
+          The preferred type of this NDEF record is NFC Forum External Type
+          (TNF=0x04), with the External Type field set to
+          <code>urn:nfc:ext:w3.org:web-nfc-wl-write</code>.
+          The payload is a string list of URL's, delimited by white space.
+        </li>
+        <li>
+          An optional additional NDEF record for blacklisting for
+          reading.
+          The preferred type of this NDEF record is NFC Forum External Type
+          (TNF=0x04), with the External Type field set to
+          <code>urn:nfc:ext:w3.org:web-nfc-bl-read</code>.
+          The payload is a string list of URL's, delimited by white space.
+        </li>
+        <li>
+          An optional additional NDEF record for blacklisting for
+          writing.
+          The preferred type of this NDEF record is NFC Forum External Type
+          (TNF=0x04), with the External Type field set to
+          <code>urn:nfc:ext:w3.org:web-nfc-bl-write</code>.
+          The payload is a string list of URL's, delimited by white space.
+        </li>
       </ul>
     </p>
-    <section> <h3>Web NFC identification</h3>
-      <p>
-        For making Web NFC tags distinct from generic NFC tags, the use of a
-        special additional record is proposed. The preferred type of this
-        NDEF record is NFC Forum External Type (TNF=0x04), with the
-        External Type field set to e.g.
-        <code>urn:nfc:ext:w3.org:web-nfc-id</code>.
-      </p>
-      <p>
-        The payload of this NDEF record MAY contain additional data in order
-        to make statistically even less probable that a generic NFC tag would
-        accidentally match with a Web NFC tag. For this purpose, the simplest
-        would be to use a cryptographic hash, for instance the SHA256 hash of
-        a well known string such as "<code>w3.org/web-nfc</code>".
-        This would be public information. Together with the external type
-        namespaced to <code>w3.org:web-nfc</code>, this is considered to be
-        good enough for ensuring practical uniqueness of Web NFC tags.
-      </p>
-      <p>
-        If Web NFC tags become popular, more and more tags may be added the
-        special records identifying Web NFC tags, making them compatible with
-        the Web NFC API. This is completely fine, once the creator of the tag
-        understands to risks associated with accessing the tags from untrusted
-        web pages.
-      </p>
-    </section>
-    <section> <h3>Web NFC white list for reading</h3>
-      <p>
-        In addition to an identification record, Web NFC tags MAY also contain
-        additional special NDEF records containing a list of URL's as payload.
-        The preferred type of this NDEF record is NFC Forum External Type
-        (TNF=0x04), with the External Type field set to e.g.
-        <code>urn:nfc:ext:w3.org:web-nfc-wl-read</code>.
-        The payload is a string list of URL's, delimited by white space.
-      </p>
-    </section>
-    <section> <h3>Web NFC white list for writing</h3>
-      <p>
-        Web NFC tags MAY also contain another special NDEF record containing a
-        list of URL's permitted to write to the tag.
-        The preferred type of this NDEF record is NFC Forum External Type
-        (TNF=0x04), with the External Type field set to e.g.
-        <code>urn:nfc:ext:w3.org:web-nfc-wl-write</code>.
-        The payload is a string list of URL's, delimited by white space.
-      </p>
-    </section>
-    <section> <h3>Web NFC black list for reading</h3>
-      <p>
-        Web NFC tags MAY also contain another special NDEF record containing a
-        list of URL's specifically NOT permitted to read to the tag.
-        The preferred type of this NDEF record is NFC Forum External Type
-        (TNF=0x04), with the External Type field set to e.g.
-        <code>urn:nfc:ext:w3.org:web-nfc-bl-read</code>.
-        The payload is a string list of URL's, delimited by white space.
-      </p>
-    </section>
-    <section> <h3>Web NFC black list for writing</h3>
-      <p>
-        Web NFC tags MAY also contain another special NDEF record containing a
-        list of URL's specifically NOT permitted to write to the tag.
-        The preferred type of this NDEF record is NFC Forum External Type
-        (TNF=0x04), with the External Type field set to e.g.
-        <code>urn:nfc:ext:w3.org:web-nfc-bl-write</code>.
-        The payload is a string list of URL's, delimited by white space.
-      </p>
-    </section>
+  </section>
+  <section> <h3>Web NFC using encoded metadata</h3>
+    <p>
+      Web NFC may also define an own format for accepted NDEF records,
+      where the preferred type of this NDEF record is NFC Forum External Type
+      (TNF=0x04), with the External Type field set to
+      <code>urn:nfc:ext:w3.org:webnfc</code>. The payload type would be
+      <code>application/webnfc+json</code> (by default UTF-8 encoded). All data
+      would be JSON, for instance with the following schema:
+      <ul>
+        <li>
+          <code>id</code>: <code>"string"</code>; contains the Web NFC
+          identifier, e.g. the SHA256 signature of <code>"w3.org/web-nfc”</code>
+        </li>
+        <li>
+          <code>scope</code>: <code>"string"</code>; contains the origin of the
+          data; it can be also stored at the NDEF record's
+          <code>id</code> field.
+        </li>
+        <li>
+          <code>messageType</code>: <code>"string"</code>; contains the type of
+          the data, either <code>"text"</code>, <code>"url"</code>,
+          <code>"json"</code>, or <code>"blob"</code>.
+        </li>
+        <li>
+          <code>message</code>: <code>"string"</code>; contains the payload data
+          encoded as text (text, URL and JSON), and for blob encoded as Base64.
+        </li>
+        <li>
+          <code>whitelistRead</code>: <code>"array"</code>; contains the URL
+          scopes that are explicitly allowed to read the data. No other scope
+          is permitted to read the data.
+        </li>
+        <li>
+          <code>whitelistWrite</code>: <code>"array"</code>; contains the URL
+          scopes that are explicitly allowed to rewrite the data. No other scope
+          is permitted to rewrite (update) the data.
+        </li>
+        <li>
+          <code>blacklistRead</code>: <code>"array"</code>; contains the URL
+          scopes that are explicitly disallowed from reading the data.
+        </li>
+        <li>
+          <code>blacklistWrite</code>: <code>"array"</code>; contains the URL
+          scopes that are explicitly disallowed to rewrite the data.
+        </li>
+      </ul>
+    </p>
   </section>
 </section>
 

--- a/security-privacy.html
+++ b/security-privacy.html
@@ -231,10 +231,12 @@
       pattern for matching the URL's that are explicitly allowed to access
       the data, for instance <br>
       <code>{ "scope": "https://mydomain.com", "write": "true"}</code>. <br>
-      Scopes not matching this are not permitted to access the data. If the
-      whitelist is empty, then the platform default policy applies, which SHOULD
-      permit reading for everyone, but SHOULD prevent writing, except to URL's
-      matching the origin of the page which has written the data.
+      Scopes which don't
+      <a href="http://w3c.github.io/web-nfc/#the-within-scope-algorithm">match</a> this are not permitted to access the data.
+      If the whitelist is empty, then the platform default policy applies,
+      which SHOULD permit reading for everyone, but SHOULD prevent writing,
+      except to URL's which
+      <a href="http://w3c.github.io/web-nfc/#the-within-scope-algorithm">match</a> the origin of the page which wrote the existing data.
     </p>
     <p>
       When the <dfn id="widl-NfcAccess-write">write</dfn> property is
@@ -243,7 +245,8 @@
     </p>
     <p class="issue">
       The exact meaning of scope, pattern, and the matching algorithm to origins
-      needs to be defined.
+      need to be reviewed with the
+      <a href="http://www.w3.org/2011/webappsec/">Web Application Security WG</a>.
     </p>
   </section>
 
@@ -271,8 +274,8 @@
   </section>
   <section> <h3>Web NFC using encoded metadata</h3>
     <p>
-      As an alternative to the previous section, Web NFC may also define an own
-      record format, based on NFC Forum External Type (TNF=0x04) records, where
+      As an alternative to the previous section, Web NFC may also define a
+      record format based on NFC Forum External Type (TNF=0x04) records, where
       the External Type field set to <code>urn:nfc:ext:w3.org:webnfc</code>.
       The payload type is <code>application/webnfc+json</code> (encoded as
       UTF-8 by default). All data is JSON, with the following schema:

--- a/security-privacy.html
+++ b/security-privacy.html
@@ -286,7 +286,7 @@
           <code>"w3.org/web-nfc”</code>. This is not strictly needed.
         </li>
         <li>
-          <code>scope</code>: <code>"string"</code>; contains the
+          <code>origin</code>: <code>"string"</code>; contains the
           <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">ASCII serialized origin</a> which
           has written the data. Also, this is not strictly needed, since it can
           be also stored at the NDEF record's <code>id</code> field.
@@ -303,7 +303,7 @@
         </li>
         <li>
           <code>access</code>: <code>"array"</code>; contains the
-          <a>whitelist</a> for access control.
+          <a>whitelist</a> for defining access control to the data.
         </li>
       </ul>
       <!--
@@ -318,8 +318,8 @@
               "id": "http://w3.org/web-nfc/id",
               "type": "string"
             },
-            "scope": {
-              "id": "http://w3.org/web-nfc/scope",
+            "origin": {
+              "id": "http://w3.org/web-nfc/origin",
               "type": "string"
             },
             "messageType": {
@@ -352,8 +352,7 @@
             }
           },
           "required": [
-            "id",
-            "scope",
+            "origin",
             "messageType",
             "message",
           ]

--- a/security-privacy.html
+++ b/security-privacy.html
@@ -51,6 +51,12 @@
               publisher: "W3C",
               date: "25 March 2015",
             },
+            "Base64": {
+              href: "https://tools.ietf.org/html/rfc4648",
+              title: "The Base16, Base32, and Base64 Data Encodings",
+              publisher: "IETF",
+              date: "October 2006",
+            },
           },
 
     };
@@ -198,8 +204,6 @@
         generic NFC tags</li>
       <li>a mechanism for whitelisting URL's that can read, or write a certain
         Web NFC tag</li>
-      <li>a mechanism for blacklisting URI's that can read, or write a certain
-        Web NFC tag.</li>
     </ul>
   </p>
 </section>
@@ -210,12 +214,12 @@
     related mechanisms. The following implementation alternatives are possible:
     <ul>
       <li>
-        Use additional NDEF records in an NDEF message containing
-        Web NFC specific metadata, such as identification, whitelists and
-        blacklists.
+        Use additional NDEF records in an NDEF message, containing
+        metadata specific to Web NFC specific, such as identification, and
+        whitelists for reading and writing.
       </li>
-        Use a specific Web NFC record format and encode the Web NFC specific
-        metadata into that.
+        Use a specific Web NFC record format and encode the metadata specific to
+        Web NFC into that.
       </li>
     </ul>
   </p>
@@ -226,41 +230,23 @@
       <ul>
         <li>Normal NDEF records carrying data.</li>
         <li>
-          An additional NDEF record for identification.
-          The preferred type of this NDEF record is NFC Forum External Type
-          (TNF=0x04), with the External Type field set to e.g.
-          <code>urn:nfc:ext:w3.org:web-nfc-id</code>.
-        </li>
-        <li>
-          An optional additional NDEF record for whitelisting for
-          reading.
+          An additional NDEF record for Web NFC identification.
           The preferred type of this NDEF record is NFC Forum External Type
           (TNF=0x04), with the External Type field set to
-          <code>urn:nfc:ext:w3.org:web-nfc-wl-read</code>.
+          <code>urn:nfc:ext:w3.org:webnfc-id</code>.
+        </li>
+        <li>
+          Optionally, a NDEF record representing a read whitelist.
+          The preferred type of this NDEF record is NFC Forum External Type
+          (TNF=0x04), with the External Type field set to
+          <code>urn:nfc:ext:w3.org:webnfc-rwl</code>.
           The payload is a string list of URL's, delimited by white space.
         </li>
         <li>
-          An optional additional NDEF record for whitelisting for
-          writing.
+          Optionally, a NDEF record representing a write whitelist.
           The preferred type of this NDEF record is NFC Forum External Type
           (TNF=0x04), with the External Type field set to
-          <code>urn:nfc:ext:w3.org:web-nfc-wl-write</code>.
-          The payload is a string list of URL's, delimited by white space.
-        </li>
-        <li>
-          An optional additional NDEF record for blacklisting for
-          reading.
-          The preferred type of this NDEF record is NFC Forum External Type
-          (TNF=0x04), with the External Type field set to
-          <code>urn:nfc:ext:w3.org:web-nfc-bl-read</code>.
-          The payload is a string list of URL's, delimited by white space.
-        </li>
-        <li>
-          An optional additional NDEF record for blacklisting for
-          writing.
-          The preferred type of this NDEF record is NFC Forum External Type
-          (TNF=0x04), with the External Type field set to
-          <code>urn:nfc:ext:w3.org:web-nfc-bl-write</code>.
+          <code>urn:nfc:ext:w3.org:webnfc-wwl</code>.
           The payload is a string list of URL's, delimited by white space.
         </li>
       </ul>
@@ -268,12 +254,12 @@
   </section>
   <section> <h3>Web NFC using encoded metadata</h3>
     <p>
-      Web NFC may also define an own format for accepted NDEF records,
+      Web NFC may also define an own NDEF extended record format,
       where the preferred type of this NDEF record is NFC Forum External Type
       (TNF=0x04), with the External Type field set to
-      <code>urn:nfc:ext:w3.org:webnfc</code>. The payload type would be
-      <code>application/webnfc+json</code> (by default UTF-8 encoded). All data
-      would be JSON, for instance with the following schema:
+      <code>urn:nfc:ext:w3.org:webnfc</code>. The payload type is
+      <code>application/webnfc+json</code> (encoded as UTF-8 by default). All
+      data is JSON, with the following schema:
       <ul>
         <li>
           <code>id</code>: <code>"string"</code>; contains the Web NFC
@@ -291,28 +277,90 @@
         </li>
         <li>
           <code>message</code>: <code>"string"</code>; contains the payload data
-          encoded as text (text, URL and JSON), and for blob encoded as Base64.
+          encoded as text (text, URL and JSON), and for blob encoded as
+          [[Base64]].
         </li>
         <li>
-          <code>whitelistRead</code>: <code>"array"</code>; contains the URL
-          scopes that are explicitly allowed to read the data. No other scope
-          is permitted to read the data.
-        </li>
-        <li>
-          <code>whitelistWrite</code>: <code>"array"</code>; contains the URL
-          scopes that are explicitly allowed to rewrite the data. No other scope
-          is permitted to rewrite (update) the data.
-        </li>
-        <li>
-          <code>blacklistRead</code>: <code>"array"</code>; contains the URL
-          scopes that are explicitly disallowed from reading the data.
-        </li>
-        <li>
-          <code>blacklistWrite</code>: <code>"array"</code>; contains the URL
-          scopes that are explicitly disallowed to rewrite the data.
+          <code>access</code>: <code>"array"</code>; contains tuples
+          for the desired access type (read-write, or read-only),
+          and the URL scopes that are explicitly allowed to access the data,
+          for instance
+          <code>{ "scope": "https://mydomain.com", "write": "true"}</code>.
+          Scopes not matching this are not permitted to access the data.
+          If the list is empty, then the platform default policy applies, which
+          SHOULD permit reading for everyone, but SHOULD prevent writing, except
+          to sub-scopes of the URL scope of the page which has created the data.
         </li>
       </ul>
+      <!--
+      The full JSON schema is the following:
+      <pre title = "Web NFC JSON schema" class="example">
+        {
+          "$schema": "http://w3.org/web-nfc#",
+          "id": "http://w3.org/web-nfc",
+          "type": "object",
+          "properties": {
+            "id": {
+              "id": "http://w3.org/web-nfc/id",
+              "type": "string"
+            },
+            "scope": {
+              "id": "http://w3.org/web-nfc/scope",
+              "type": "string"
+            },
+            "messageType": {
+              "id": "http://w3.org/web-nfc/messageType",
+              "type": "string"
+            },
+            "message": {
+              "id": "http://w3.org/web-nfc/message",
+              "type": "string"
+            },
+            "access": {
+              "id": "http://w3.org/web-nfc/access",
+              "type": "array",
+              "items": [
+                {
+                  "id": "http://w3.org/web-nfc/access/0",
+                  "type": "object",
+                  "properties": {
+                    "scope": {
+                      "id": "http://w3.org/web-nfc/access/0/scope",
+                      "type": "string"
+                    },
+                    "access": {
+                      "id": "http://w3.org/web-nfc/access/0/access",
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "id": "http://w3.org/web-nfc/access/1",
+                  "type": "object",
+                  "properties": {
+                    "scope": {
+                      "id": "http://w3.org/web-nfc/access/1/scope",
+                      "type": "string"
+                    },
+                    "access": {
+                      "id": "http://w3.org/web-nfc/access/1/access",
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "id",
+            "scope",
+            "messageType",
+            "message",
+          ]
+        }
+      </pre>
     </p>
+    -->
     <p class="note">
       The encoded JSON format for Web NFC data and metadata is useful for
       abstracting away NFC Forum types, and for supporting implementations where

--- a/security-privacy.html
+++ b/security-privacy.html
@@ -51,12 +51,6 @@
               publisher: "W3C",
               date: "25 March 2015",
             },
-            "Base64": {
-              href: "https://tools.ietf.org/html/rfc4648",
-              title: "The Base16, Base32, and Base64 Data Encodings",
-              publisher: "IETF",
-              date: "October 2006",
-            },
           },
 
     };
@@ -223,52 +217,76 @@
       </li>
     </ul>
   </p>
-  <section> <h3>Web NFC using additional NDEF records for metadata</h3>
+  <section> <h3>Whitelists and the <strong>NfcAccess</strong> dictionary</h3>
+    <p>
+      A <dfn>whitelist</dfn> is an array of <code>NfcAccess</code>
+      dictionaries.
+    </p>
+    <dl title="dictionary NfcAccess" class="idl">
+      <dt>DOMString scope</dt>
+      <dt>boolean write</dt>
+    </dl>
+    <p>
+      The <dfn id="widl-NfcAccess-scope">scope</dfn> property is a string
+      pattern for matching the URL's that are explicitly allowed to access
+      the data, for instance <br>
+      <code>{ "scope": "https://mydomain.com", "write": "true"}</code>. <br>
+      Scopes not matching this are not permitted to access the data. If the
+      whitelist is empty, then the platform default policy applies, which SHOULD
+      permit reading for everyone, but SHOULD prevent writing, except to URL's
+      matching the origin of the page which has written the data.
+    </p>
+    <p>
+      When the <dfn id="widl-NfcAccess-write">write</dfn> property is
+      <code>true</code>, then the URL's matching <code><var>scope</var></code>
+      are permitted to write (in fact, update) the data, otherwise they are only permitted to read it.
+    </p>
+    <p class="issue">
+      The exact meaning of scope, pattern, and the matching algorithm to origins
+      needs to be defined.
+    </p>
+  </section>
+
+  <section> <h3>Additional NDEF records for Web NFC</h3>
     <p>
       A typical Web NFC NDEF message will contain the following
       NDEF records:
       <ul>
         <li>Normal NDEF records carrying data.</li>
         <li>
-          An additional NDEF record for Web NFC identification.
+          Optionally, an NDEF record for Web NFC identification.
           The preferred type of this NDEF record is NFC Forum External Type
           (TNF=0x04), with the External Type field set to
           <code>urn:nfc:ext:w3.org:webnfc-id</code>.
         </li>
         <li>
-          Optionally, a NDEF record representing a read whitelist.
+          Optionally, a NDEF record representing a <a>whitelist</a>.
           The preferred type of this NDEF record is NFC Forum External Type
           (TNF=0x04), with the External Type field set to
-          <code>urn:nfc:ext:w3.org:webnfc-rwl</code>.
-          The payload is a string list of URL's, delimited by white space.
-        </li>
-        <li>
-          Optionally, a NDEF record representing a write whitelist.
-          The preferred type of this NDEF record is NFC Forum External Type
-          (TNF=0x04), with the External Type field set to
-          <code>urn:nfc:ext:w3.org:webnfc-wwl</code>.
-          The payload is a string list of URL's, delimited by white space.
+          <code>urn:nfc:ext:w3.org:webnfc-wl</code>.
+          The payload is an array of <code><a>NfcAccess</a></code> dictionaries.
         </li>
       </ul>
     </p>
   </section>
   <section> <h3>Web NFC using encoded metadata</h3>
     <p>
-      Web NFC may also define an own NDEF extended record format,
-      where the preferred type of this NDEF record is NFC Forum External Type
-      (TNF=0x04), with the External Type field set to
-      <code>urn:nfc:ext:w3.org:webnfc</code>. The payload type is
-      <code>application/webnfc+json</code> (encoded as UTF-8 by default). All
-      data is JSON, with the following schema:
+      As an alternative to the previous section, Web NFC may also define an own
+      record format, based on NFC Forum External Type (TNF=0x04) records, where
+      the External Type field set to <code>urn:nfc:ext:w3.org:webnfc</code>.
+      The payload type is <code>application/webnfc+json</code> (encoded as
+      UTF-8 by default). All data is JSON, with the following schema:
       <ul>
         <li>
           <code>id</code>: <code>"string"</code>; contains the Web NFC
-          identifier, e.g. the SHA256 signature of <code>"w3.org/web-nfc”</code>
+          identifier, e.g. the SHA256 signature of
+          <code>"w3.org/web-nfc”</code>. This is not strictly needed.
         </li>
         <li>
-          <code>scope</code>: <code>"string"</code>; contains the origin of the
-          data; it can be also stored at the NDEF record's
-          <code>id</code> field.
+          <code>scope</code>: <code>"string"</code>; contains the
+          <a href="https://html.spec.whatwg.org/multipage/browsers.html#ascii-serialisation-of-an-origin">ASCII serialized origin</a> which
+          has written the data. Also, this is not strictly needed, since it can
+          be also stored at the NDEF record's <code>id</code> field.
         </li>
         <li>
           <code>messageType</code>: <code>"string"</code>; contains the type of
@@ -278,18 +296,11 @@
         <li>
           <code>message</code>: <code>"string"</code>; contains the payload data
           encoded as text (text, URL and JSON), and for blob encoded as
-          [[Base64]].
+          Base64 ([[RFC4648]]).
         </li>
         <li>
-          <code>access</code>: <code>"array"</code>; contains tuples
-          for the desired access type (read-write, or read-only),
-          and the URL scopes that are explicitly allowed to access the data,
-          for instance
-          <code>{ "scope": "https://mydomain.com", "write": "true"}</code>.
-          Scopes not matching this are not permitted to access the data.
-          If the list is empty, then the platform default policy applies, which
-          SHOULD permit reading for everyone, but SHOULD prevent writing, except
-          to sub-scopes of the URL scope of the page which has created the data.
+          <code>access</code>: <code>"array"</code>; contains the
+          <a>whitelist</a> for access control.
         </li>
       </ul>
       <!--
@@ -328,26 +339,12 @@
                       "id": "http://w3.org/web-nfc/access/0/scope",
                       "type": "string"
                     },
-                    "access": {
-                      "id": "http://w3.org/web-nfc/access/0/access",
-                      "type": "string"
+                    "write": {
+                      "id": "http://w3.org/web-nfc/access/0/write",
+                      "type": "boolean"
                     }
                   }
                 },
-                {
-                  "id": "http://w3.org/web-nfc/access/1",
-                  "type": "object",
-                  "properties": {
-                    "scope": {
-                      "id": "http://w3.org/web-nfc/access/1/scope",
-                      "type": "string"
-                    },
-                    "access": {
-                      "id": "http://w3.org/web-nfc/access/1/access",
-                      "type": "string"
-                    }
-                  }
-                }
               ]
             }
           },


### PR DESCRIPTION
There is much rearrangement of the text. In essence, added an encoded JSON format for Web NFC data and metadata, both for abstracting away NFC Forum types, and for supporting implementations where an NDEF message contains only one NDEF record.
