### PR TITLE
point to LICENSE instead of repeating it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 This repository is being used for work in the W3C Web NFC Community Group. All
 contributions are made under the
-[W3C CLA](https://www.w3.org/community/about/agreements/cla/).
+terms described in the LICENSE.md file.
 To contribute, you must join the W3C Web NFC Community Group at [https://www.w3.org/community/web-nfc/](https://www.w3.org/community/web-nfc/).
 
 We intend to reject Pull Requests from anyone who has not joined the Community
@@ -8,5 +8,4 @@ Group (which requires agreement to the terms of the W3C CLA). If any Pull
 Requests from you are inadvertently accepted and you are not a W3C Web NFC
 Community Group member, the act of making a Pull Request indicates that you
 represent that you have received permission to make Contributions on behalf of
-your employer and that the Contribution is made under the terms of the W3C
-CLA.
+your employer and that the Contribution is made under the terms described in the LICENSE.md file in this repository.


### PR DESCRIPTION
What the license is should be in the LICENSE.md file.  Currently the CONTRIBUTING text repeats it, meaning if LICENSE changes this would have to change to match.  Better to just refer to the LICENSE file.
