### PR TITLE
update CONTRIBUTING to match what W3C is using

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,4 @@
-W3C Web NFC Community Group
-
-This repository is being used for work in the [W3C Web NFC Community Group](https://www.w3.org/community/web-nfc/), governed by the [W3C Community License Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). 
+This repository is being used for work in the W3C Web NFC Community Group, governed by the [W3C Community License Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). 
 To contribute, you must join the [W3C Web NFC Community Group](https://www.w3.org/community/web-nfc/).
 
 If you are not the sole contributor to a contribution (pull request), please identify all contributors in the 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,8 @@
-This repository is being used for work in the W3C Web NFC Community Group. All
-contributions are made under the
-terms described in the LICENSE.md file.
-To contribute, you must join the W3C Web NFC Community Group at [https://www.w3.org/community/web-nfc/](https://www.w3.org/community/web-nfc/).
+W3C Web NFC Community Group
 
-We intend to reject Pull Requests from anyone who has not joined the Community
-Group (which requires agreement to the terms of the W3C CLA). If any Pull
-Requests from you are inadvertently accepted and you are not a W3C Web NFC
-Community Group member, the act of making a Pull Request indicates that you
-represent that you have received permission to make Contributions on behalf of
-your employer and that the Contribution is made under the terms described in the LICENSE.md file in this repository.
+This repository is being used for work in the [W3C Web NFC Community Group](https://www.w3.org/community/web-nfc/), governed by the [W3C Community License Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). 
+To contribute, you must join the [W3C Web NFC Community Group](https://www.w3.org/community/web-nfc/).
+
+If you are not the sole contributor to a contribution (pull request), please identify all contributors in the 
+commit message. In the commit, include on a new line,
+<pre>Contributors: +@githubusername1, +@githubusername2, ...</pre>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# W3C Web NFC Community Group
+
 This repository is being used for work in the W3C Web NFC Community Group, governed by the [W3C Community License Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). 
 To contribute, you must join the [W3C Web NFC Community Group](https://www.w3.org/community/web-nfc/).
 


### PR DESCRIPTION
W3C Web Platform Incubator Community Group (WICG) will use the same CONTRIBUTING and LICENSE files in repositories for each of its specs.  These files were created by W3C.  The LICENSE file was taken from the one used by this Web NFC CG, so no change it needed.  Their CONTRIBUTING file started with the Web NFC one, but has modifications to be able to automate detecting all Contributors.  There will be tools to do that for CGs that match the new format specified in the CONTRIBUTING file.  This PR is to make our file match what will be the new standard file. Please see the CONTRIBUTING file linked to in the WICG Charter https://wicg.github.io/admin/charter.html#contrib 
