### PR TITLE
Make reference to WebIDL spec consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -243,7 +243,7 @@
       <code><dfn>ArrayBuffer</dfn></code></a>,
     <a href="http://heycam.github.io/webidl/#common-BufferSource">
       <code><dfn>BufferSource</dfn></code></a> and
-    <a href="http://www.w3.org/TR/WebIDL/#idl-any">
+    <a href="http://heycam.github.io/webidl/#idl-any">
       <code><dfn>any</dfn></code></a>
     are defined in [[!WEBIDL]].
   </p>


### PR DESCRIPTION
Not sure if it is good to link to an Editor's Draft in normative
reference. But it is good to use the same version of reference.

Actually the Published version has no definition of ArrayBuffer
and BufferSource.
