### PR TITLE
Add extended attributes to navigator.nfc

### DIFF
--- a/index.html
+++ b/index.html
@@ -1417,7 +1417,7 @@ navigator.nfc.push({ records: [
   </p>
   <pre class="idl">
     partial interface Navigator {
-      readonly attribute NFC nfc;
+      [SecureContext, SameObject] readonly attribute NFC nfc;
     };
   </pre>
   <!-- - - - - - - - - - - - nfc attribute  - - - - - - - - - - - -->


### PR DESCRIPTION
This change adds two extended attributes to navigator.nfc for the
following reasons.
  - [SecureContext]
    - We already added this to `NFC` interface[1] but it was not enough.
      Should provide feature-detection[2].
  - [SameObject]
    - There is no reason to create a new object whenever accessing
      `navigator.nfc`.

[1] https://github.com/w3c/web-nfc/pull/143
[2] https://chromium-review.googlesource.com/c/chromium/src/+/989537#message-eab848bd9bc7fba8b163630d3731c9d851a87ac3