### PR TITLE
Remove uncommon sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,10 +137,6 @@
     the Candidate Recommendation phase should subscribe to the repository on
     GitHub and take part in the discussions.
   </p>
-  <p>
-    Significant changes to this document since last publication are
-    documented in the <a href="#Changes">Changes section</a>.
-  </p>
 </section>
 
 <!-- - - - - - - - - - - - - - - Conformance  - - - - - - - - - - - - - - - -->
@@ -3128,61 +3124,6 @@ writer.push({ records: [
     </ol>
     </section>
   </section> <!-- receiving content -->
-</section>
-
-<!-- - - - - - - - - - - - - - -  Changes - - - - - - - - - - - - - - - - - -->
-<section class="appendix" id="Changes"><h2>Changes</h2>
-  <p>
-    The following is a list of substantial changes to the document. For a
-    complete list of changes, see the <a href=
-    "https://github.com/w3c/web-nfc/commits/gh-pages">change log on
-    Github</a>. You can also view the <a href=
-    "https://github.com/w3c/web-nfc/issues?page=1&amp;state=closed">
-    recently closed bugs</a>.
-  </p>
-  <ul>
-    <li>Corrections in the usage of origin.</li>
-    <li>Defined <code><a>NFCRecordData</a></code> as explicit union.</li>
-    <li>Defined <code><a>NFCMessage</a></code> as a dictionary.</li>
-    <li>Improved definitions for URL and match pattern.</a>
-    <li>Added section for handling visibility and focus.</li>
-    <li>Added internal slots to <code>NFC</code>.</li>
-    <li>Changed push policy for background pages.</li>
-    <li>Changed receive policy for background pages.</li>
-    <li>Updated security policies and related algorithmic steps.</li>
-    <li>Moved to contructor objects</li>
-  </ul>
-</section>
-
-<!-- - - - - - - - - - - - - - - Open issues - - - - - - - - - - - - - - - -->
-<section> <h3 class="appendix" id="openissues">Open issues</h3>
-  <p>
-    The following problems are being discussed and need most attention:
-    <ul>
-      <li>
-        <a href="https://github.com/w3c/web-nfc/issues/2">
-        Verify security model.</a>
-      </li>
-      <li>
-        <a href="https://github.com/w3c/web-nfc/issues/3">
-        Suggest a permission UI flow.</a>
-      </li>
-      <li>
-        <a href="https://github.com/w3c/web-nfc/issues/40">
-        Simplify process for obtaining permissions.</a>
-      </li>
-      <li>
-        <a href="https://github.com/w3c/web-nfc/issues/17">
-        Using service workers and protocol handlers.</a>
-      </li>
-      <li>
-        <a href="https://github.com/w3c/web-nfc/issues/53">
-        How much needs to be hidden from pages that lose focus during NFC
-        operations?</a>
-      </li>
-    </ul>
-    This version addresses the issues above, and also other issues.
-  </p>
 </section>
 
 <section id="idl-index" class="appendix">


### PR DESCRIPTION
The spec has two sections to track changed and open issues but they
are not kept up to date, and they are uncommon in specs today.

After discussing with @anssiko  I have decided to remove these