### PR TITLE
Replace NDEFRecordData data() with multiple getters

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,8 +771,8 @@ const reader = new NFCReader({url: document.baseURI, recordType: "json"});
 
 reader.addEventListener("reading", event => {
   for (let record of event.message.records) {
-    let json = record.toJSON();
-    let article =/[aeio]/.test(json.title) ? "an" : "a";
+    const json = record.toJSON();
+    const article =/[aeio]/.test(json.title) ? "an" : "a";
     console.log(`${json.name} is ${article} ${json.title}`);
   }
 });
@@ -1203,9 +1203,9 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       };
     </pre>
     <p>
-      <a>NDEFRecord</a> objects have an associated <dfn id="ndefrecord-bytes">bytes</dfn>
-      (a <a>byte sequence</a>) set on creation that represents the payload data of the
-      <a>NDEF record</a>, which is `null` if there was no data in the
+      <a>NDEFRecord</a> objects have associated <dfn id="ndefrecord-bytes">bytes</dfn>
+      (a <a>byte sequence</a>), set on creation that represents the payload data of the
+      <a>NDEF record</a>, which is `null` if there were no data in the
       <a>NDEF record</a>.
     </p>
     <p>
@@ -1224,7 +1224,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
     <p>
       The <dfn data-dfn-for="NDEFRecord">toText()</dfn> method, when invoked, MUST return the
       result of running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
-      and a `text` type, unless there's other specific illustration in step 7 of
+      and a `text` type, unless there's another specific illustration in step 7 of
       <a href="#the-nfc-reading-algorithm">The NFC reading algorithm</a>.
     </p>
     <p>
@@ -1264,7 +1264,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           <dt>text</dt>
           <ol>
             <li>
-              If the <var>recordType</var> value is not equal to <code>"empty"</code>, then
+              If the <var>recordType</var> value is not equal to "`empty`", then
               return the result of running <a>UTF-8 decode</a> on <var>bytes</var>.
             </li>
             <li>
@@ -1274,8 +1274,8 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           <dt>arrayBuffer</dt>
           <ol>
             <li>
-              If the <var>recordType</var> value is equal to <code>"json"</code> or
-              <code>"opaque"</code>, then return an {{ArrayBuffer}} whose contents are the
+              If the <var>recordType</var> value is equal to "`json`" or
+              "`opaque`", then return an {{ArrayBuffer}} whose contents are the
               <var>bytes</var>. Re-throw any exceptions.
             </li>
             <li>
@@ -1285,8 +1285,8 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           <dt>JSON</dt>
           <ol>
             <li>
-              If the <var>recordType</var> value is equal to <code>"json"</code> or
-              <code>"opaque"</code>, then return the result of running <a>parse JSON from bytes</a>
+              If the <var>recordType</var> value is equal to "`json`" or
+              "`opaque`", then return the result of running <a>parse JSON from bytes</a>
               on <var>bytes</var>. Re-throw any exceptions.
             </li>
             <li>

--- a/index.html
+++ b/index.html
@@ -445,7 +445,7 @@
     The <dfn>Web NFC message origin</dfn> is a <a>serialized origin</a>
     with <code>"https"</code> scheme, stored in the <a>Web NFC record</a>.
     For <a>NFC content</a> that is not a <a>Web NFC message</a>, it is
-    <code>null</code>.
+    `null`.
   </p>
   <p>
     The <dfn id="web-nfc-id">Web NFC Id</dfn> is an <a>absolute-URL string</a>,
@@ -771,8 +771,9 @@ const reader = new NFCReader({url: document.baseURI, recordType: "json"});
 
 reader.addEventListener("reading", event => {
   for (let record of event.message.records) {
-    let article =/[aeio]/.test(record.toJSON().title) ? "an" : "a";
-    console.log(`${record.toJSON().name} is ${article} ${record.toJSON().title}`);
+    let json = record.toJSON();
+    let article =/[aeio]/.test(json.title) ? "an" : "a";
+    console.log(`${json.name} is ${article} ${json.title}`);
   }
 });
 
@@ -1190,9 +1191,9 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       interface NDEFRecord {
         readonly attribute NDEFRecordType recordType;
         readonly attribute USVString mediaType;
-        [NewObject] USVString toText();
+        USVString toText();
         [NewObject] ArrayBuffer toArrayBuffer();
-        [NewObject] any toJSON();
+        [NewObject] object toJSON();
       };
 
       dictionary NDEFRecordInit {
@@ -1204,7 +1205,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
     <p>
       <a>NDEFRecord</a> objects have an associated <dfn id="ndefrecord-bytes">bytes</dfn>
       (a <a>byte sequence</a>) set on creation that represents the payload data of the
-      <a>NDEF record</a>, which is <code>null</code> if there was no data in the
+      <a>NDEF record</a>, which is `null` if there was no data in the
       <a>NDEF record</a>.
     </p>
     <p>
@@ -1212,27 +1213,29 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       for <a href="#dom-ndefrecordinit-data">NDEFRecordInit.data</a> property.
     </p>
     <p>
-      The <dfn>NDEFRecord.mediaType</dfn>
+      The <dfn data-dfn-for="NDEFRecord">mediaType</dfn>
       property represents the <a>MIME type</a> of the <a>NDEF record</a>
       payload.
     </p>
     <p>
-      The <dfn>NDEFRecord.recordType</dfn> property represents the
+      The <dfn data-dfn-for="NDEFRecord">recordType</dfn> property represents the
       <a>NDEF record</a> types.
     </p>
     <p>
-      The <dfn>NDEFRecord.toText()</dfn> method, when invoked, MUST return the
-      result of running <a>convert an NDEFRecord object's bytes</a> with <i>text</i>,
-      unless there's other specific illustration in step 7 of
+      The <dfn data-dfn-for="NDEFRecord">toText()</dfn> method, when invoked, MUST return the
+      result of running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
+      and a `text` type, unless there's other specific illustration in step 7 of
       <a href="#the-nfc-reading-algorithm">The NFC reading algorithm</a>.
     </p>
     <p>
-      The <dfn>NDEFRecord.toArrayBuffer()</dfn> method, when invoked, MUST return the
-      result of running <a>convert an NDEFRecord object's bytes</a> with <i>arrayBuffer</i>.
+      The <dfn data-dfn-for="NDEFRecord">toArrayBuffer()</dfn> method, when invoked, MUST return the
+      result of running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
+      and an `arrayBuffer` type.
     </p>
     <p>
-      The <dfn>NDEFRecord.toJSON()</dfn> method, when invoked, MUST return the
-      result of running <a>convert an NDEFRecord object's bytes</a> with <i>JSON</i>.
+      The <dfn data-dfn-for="NDEFRecord">toJSON()</dfn> method, when invoked, MUST return the
+      result of running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
+      and a `JSON` type.
     </p>
     <p>
       The <dfn>NDEFRecordInit</dfn> dictionary is used to initialize an <a>NDEF record</a>
@@ -1245,12 +1248,16 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       and <a>Writing or pushing content</a> sections.
     </p>
     <p>
-      To <dfn>convert an NDEFRecord object's bytes</dfn> to a given <var>type</var>, run these steps:
+      To <dfn>convert NDEFRecord's bytes</dfn>, pass a <var data-type="NDEFRecord">record</var>
+      and a <var>type</var>, run these steps:
     </p>
     <ol>
-      <li>Let <var>bytes</var> be the <a>NDEFRecord</a> object's associated <a>bytes</a>.
+      <li>
+        Let <var>bytes</var> be the <var>record</var>'s <a>bytes</a>.
       </li>
-      <li>Let <var>recordType</var> be the value of <a>NDEFRecord</a> object's recordType attribute.
+      <li>
+        Let <var data-type="NDEFRecordType">recordType</var> be the value of <var>record</var>'s
+        recordType attribute.
       </li>
       <li>Switch on <var>type</var>:
         <dl>
@@ -1258,10 +1265,10 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           <ol>
             <li>
               If the <var>recordType</var> value is not equal to <code>"empty"</code>, then
-              return the result of running <a>UTF-8 decode</a> on the <var>bytes</var>.
+              return the result of running <a>UTF-8 decode</a> on <var>bytes</var>.
             </li>
             <li>
-              Otherwise, return <code>null</code>.
+              Otherwise, return `null`.
             </li>
           </ol>
           <dt>arrayBuffer</dt>
@@ -1269,11 +1276,11 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
             <li>
               If the <var>recordType</var> value is equal to <code>"json"</code> or
               <code>"opaque"</code>, then return an {{ArrayBuffer}} whose contents are the
-              <var>bytes</var>. Exceptions thrown during the creation of the {{ArrayBuffer}}
-              object are re-thrown.
+              <var>bytes</var>. Re-throw any exceptions thrown by the creation of the
+              {{ArrayBuffer}} object.
             </li>
             <li>
-              Otherwise, return <code>null</code>.
+              Otherwise, return `null`.
             </li>
           </ol>
           <dt>JSON</dt>
@@ -1284,7 +1291,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
               on <var>bytes</var>. Re-throw any exceptions thrown by <a>parse JSON from bytes</a>.
             </li>
             <li>
-              Otherwise, return <code>null</code>.
+              Otherwise, return `null`.
             </li>
           </ol>
         </dl>
@@ -1368,7 +1375,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <td><dfn>"json"</dfn></td>
       <td><a>JSON MIME type</a></td>
       <td>
-        <code>null</code> or <code>DOMString</code> or <code>Number</code> or
+        `null` or <code>DOMString</code> or <code>Number</code> or
         <code>Dictionary</code>
       </td>
       <td><a>MIME type</a> (<a>TNF</a>=2) record with
@@ -1404,36 +1411,36 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <td>Empty (<a>TNF</a>=0) record</td>
       <td>"empty"</td>
       <td>""</td>
-      <td>
-        <a href="#dom-ndefrecord-totext">toText()</a> or
-        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
-        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      <td data-link-for="NDEFRecord">
+        <a>toText()</a> or
+        <a>toJSON()</a> or
+        <a>toArrayBuffer()</a>
       </td>
     </tr>
     <tr>
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type <i>Text</i></td>
       <td>"text"</td>
       <td>"text/plain"</td>
-      <td><a href="#dom-ndefrecord-totext">toText()</a></td>
+      <td data-link-for="NDEFRecord"><a>toText()</a></td>
     </tr>
     <tr>
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type <i>URI</i></td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td><a href="#dom-ndefrecord-totext">toText()</a></td>
+      <td data-link-for="NDEFRecord"><a>toText()</a></td>
     </tr>
     <tr>
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type
           <i>Smart Poster</i></td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td><a href="#dom-ndefrecord-totext">toText()</a></td>
+      <td data-link-for="NDEFRecord"><a>toText()</a></td>
     </tr>
     <tr>
       <td><a>Absolute-URL string</a> (<a>TNF</a>=3) record</td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td><a href="#dom-ndefrecord-totext">toText()</a></td>
+      <td data-link-for="NDEFRecord"><a>toText()</a></td>
     </tr>
     <tr>
       <td><a>MIME type</a> (<a>TNF</a>=2) record with
@@ -1441,20 +1448,20 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       </td>
       <td>"json"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
-      <td>
-        <a href="#dom-ndefrecord-totext">toText()</a> or
-        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
-        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      <td data-link-for="NDEFRecord">
+        <a>toText()</a> or
+        <a>toJSON()</a> or
+        <a>toArrayBuffer()</a>
       </td>
     </tr>
     <tr>
       <td><a>MIME type</a> (<a>TNF</a>=2) record</td>
       <td>"opaque"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
-      <td>
-        <a href="#dom-ndefrecord-totext">toText()</a> or
-        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
-        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      <td data-link-for="NDEFRecord">
+        <a>toText()</a> or
+        <a>toJSON()</a> or
+        <a>toArrayBuffer()</a>
       </td>
     </tr>
     <tr>
@@ -1462,20 +1469,20 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
         <code>urn:nfc:ext:w3.org:webnfc*</code></td>
       <td>"opaque"</td>
       <td>"application/octet-stream"</td>
-      <td>
-        <a href="#dom-ndefrecord-totext">toText()</a> or
-        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
-        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      <td data-link-for="NDEFRecord">
+        <a>toText()</a> or
+        <a>toJSON()</a> or
+        <a>toArrayBuffer()</a>
       </td>
     </tr>
     <tr>
       <td>Any other <a>NDEF record</a> type</td>
       <td>"opaque"</td>
       <td>"application/octet-stream"</td>
-      <td>
-        <a href="#dom-ndefrecord-totext">toText()</a> or
-        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
-        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      <td data-link-for="NDEFRecord">
+        <a>toText()</a> or
+        <a>toJSON()</a> or
+        <a>toArrayBuffer()</a>
       </td>
     </tr>
   </table>
@@ -1543,7 +1550,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
     is available. The <dfn>NFCReadingEvent.message</dfn> is an <a>NDEFMessage</a> object.
     <dfn>NFCReadingEventInit</dfn> is used to initialize a new event with a serial number
     and the <a>NDEFMessageInit</a> data via the <dfn>NFCReadingEventInit.message</dfn> member.
-    If <dfn>NFCReadingEventInit.serialNumber</dfn> is <a>not present</a> or is <dfn>null</dfn>,
+    If <dfn>NFCReadingEventInit.serialNumber</dfn> is <a>not present</a> or is `null`,
     empty string will be used to init the event.
   </p>
   <p class="note">
@@ -1952,7 +1959,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           </li>
           <li>
             Let <var>signal</var> be the <var>options</var>’ dictionary member
-            of the same name if present, or <code>null</code> otherwise.
+            of the same name if present, or `null` otherwise.
           </li>
           <li>
             If there is no underlying <a>NFC Adapter</a>, or if a connection cannot
@@ -1971,7 +1978,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
             and return <var>p</var>.
           </li>
           <li>
-            If <var>signal</var> is not <code>null</code>, then
+            If <var>signal</var> is not `null`, then
             <a>add the following abort steps</a> to <var>signal</var>:
               <ol>
                 <li>
@@ -2129,7 +2136,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                           </li>
                           <li>
                             If the <a>Web NFC message origin</a> of the read
-                            <a>NFC content</a> is <code>null</code>, or it is
+                            <a>NFC content</a> is `null`, or it is
                             different than the <a>serialized origin</a> of the
                             <a>current settings object</a>, and the
                             <a>obtain push permission</a> steps return
@@ -3017,15 +3024,15 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       </li>
       <li>
         Let <var>message</var> be a new <a>NDEFMessage</a> object, with
-        <var>message</var>'s url set to <code>null</code> and
+        <var>message</var>'s url set to `null` and
         <var>message</var>'s records set to the empty <a>list</a>.
       </li>
       <li>
         Let <var>serialNumber</var> be the device identifier as a series of
-        numbers, or <code>null</code> if unavailable.
+        numbers, or `null` if unavailable.
       </li>
       <li>
-        If <var>serialNumber</var> is not <code>null</code>, set it to the
+        If <var>serialNumber</var> is not `null`, set it to the
         <a>string</a> of U+003A (:) concatenating each number represented as
         <a>ASCII hex digit</a>, in the same order.
       </li>
@@ -3306,7 +3313,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
   <p>
     The editors would like to thank Jeffrey Yasskin, Anne van Kesteren,
     Anssi Kostiainen, Domenic Denicola, Daniel Ehrenberg, Jonas Sicking,
-    Don Coleman, Salvatore Iovene and Rijubrata Bhaumik for their
+    Don Coleman, Salvatore Iovene, Rijubrata Bhaumik and Wanming Lin for their
     contributions to this document.
   </p>
   <p>

--- a/index.html
+++ b/index.html
@@ -287,12 +287,12 @@
     are defined in [[!DOM]].
   </p>
   <p>
-    <dfn data-cite="!ENCODING#concept-stream-push">push</dfn>,
-    <dfn data-cite="!ENCODING#utf-8">UTF-8 encoding</dfn>,
-    <dfn data-cite="!ENCODING#utf-8-decode">UTF-8 decode</dfn>,
-    <dfn data-cite="!ENCODING#utf-8-encode">UTF-8 encode</dfn>,
-    <dfn data-cite="!ENCODING#encode">encode</dfn>, and
-    <dfn data-cite="!ENCODING#decode">decode</dfn> are defined in [[!ENCODING]].
+    <dfn data-cite="ENCODING#concept-stream-push">push</dfn>,
+    <dfn data-cite="ENCODING#utf-8">UTF-8 encoding</dfn>,
+    <dfn data-cite="ENCODING#utf-8-decode">UTF-8 decode</dfn>,
+    <dfn data-cite="ENCODING#utf-8-encode">UTF-8 encode</dfn>,
+    <dfn data-cite="ENCODING#encode">encode</dfn>, and
+    <dfn data-cite="ENCODING#decode">decode</dfn> are defined in [[!ENCODING]].
   </p>
 
   <section> <h3>Security related terms</h3>
@@ -1179,7 +1179,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
     </p>
   </section>
 
-  <section> <h3>The <dfn>NDEFRecord</dfn> interface</h3>
+  <section data-dfn-for="NDEFRecord"> <h3>The <dfn>NDEFRecord</dfn> interface</h3>
     <p>
       The content of any <a>NDEF record</a> is exposed by the
       <a>NDEFRecord</a> interface:
@@ -1213,28 +1213,25 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       for <a href="#dom-ndefrecordinit-data">NDEFRecordInit.data</a> property.
     </p>
     <p>
-      The <dfn data-dfn-for="NDEFRecord">mediaType</dfn>
-      property represents the <a>MIME type</a> of the <a>NDEF record</a>
-      payload.
+      The <dfn>mediaType</dfn> property represents the <a>MIME type</a> of
+      the <a>NDEF record</a> payload.
     </p>
     <p>
-      The <dfn data-dfn-for="NDEFRecord">recordType</dfn> property represents the
-      <a>NDEF record</a> types.
+      The <dfn>recordType</dfn> property represents the <a>NDEF record</a> types.
     </p>
     <p>
-      The <dfn data-dfn-for="NDEFRecord">toText()</dfn> method, when invoked, MUST return the
-      result of running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
-      and a `text` type, unless there's another specific illustration in step 7 of
-      <a href="#the-nfc-reading-algorithm">The NFC reading algorithm</a>.
+      The <dfn>toText()</dfn> method, when invoked, MUST return the result of
+      running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
+      and a `text` type.
     </p>
     <p>
-      The <dfn data-dfn-for="NDEFRecord">toArrayBuffer()</dfn> method, when invoked, MUST return the
-      result of running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
+      The <dfn>toArrayBuffer()</dfn> method, when invoked, MUST return the result of
+      running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
       and an `arrayBuffer` type.
     </p>
     <p>
-      The <dfn data-dfn-for="NDEFRecord">toJSON()</dfn> method, when invoked, MUST return the
-      result of running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
+      The <dfn>toJSON()</dfn> method, when invoked, MUST return the result of
+      running <a>convert NDEFRecord's bytes</a> with an <a>NDEFRecord</a> object
       and a `JSON` type.
     </p>
     <p>
@@ -1257,18 +1254,45 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       </li>
       <li>
         Let <var data-type="NDEFRecordType">recordType</var> be the value of <var>record</var>'s
-        recordType attribute.
+        <a data-link-for="NDEFRecord">recordType</a> attribute.
       </li>
       <li>Switch on <var>type</var>:
         <dl>
           <dt>text</dt>
           <ol>
             <li>
-              If the <var>recordType</var> value is not equal to "`empty`", then
-              return the result of running <a>UTF-8 decode</a> on <var>bytes</var>.
+              If the <var>recordType</var> value is equal to "`empty`", return `null`.
             </li>
             <li>
-              Otherwise, return `null`.
+              If the <var>recordType</var> value is equal to "`text`", then run the following sub-steps:
+              <ol>
+                <li>
+                  Let <var>header</var> be the first <a>byte</a> of <var>bytes</var>.
+                </li>
+                <li>
+                  Let <var>charset</var> be "`utf-8`" if bit 7 (most significant bit) of
+                  <var>header</var> is equal to the value 0, or else "`utf-16be`".
+                </li>
+                <li>
+                  Let <var>offset</var> be the value given by bit 5 to bit 0 of the
+                  <var>header</var>.
+                </li>
+                <li>
+                  Let <var>buffer</var> be the <var>bytes</var>,
+                  from position <var>offset</var> + 1 to the end.
+                </li>
+                <li>
+                  If <var>charset</var> is equal to "`utf-8`", return the result of
+                  running <a>UTF-8 decode</a> on <var>buffer</var>.
+                </li>
+                <li>
+                  Otherwise, return the result of running <a>decode</a> on
+                  <var>buffer</var> with `encoding` set to "`utf-16be`".
+                </li>
+              </ol>
+            </li>
+            <li>
+              Otherwise, return the result of running <a>UTF-8 decode</a> on <var>bytes</var>.
             </li>
           </ol>
           <dt>arrayBuffer</dt>
@@ -1399,7 +1423,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
     <a href="#steps-receiving">Receiving and parsing content</a> section, is as
     follows:
   </p>
-  <table class="simple">
+  <table class="simple" data-link-for="NDEFRecord">
     <tr>
       <th>NDEF record type</th>
       <th>NDEFRecord recordType</th>
@@ -1410,7 +1434,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <td>Empty (<a>TNF</a>=0) record</td>
       <td>"empty"</td>
       <td>""</td>
-      <td data-link-for="NDEFRecord">
+      <td>
         <a>toText()</a> or
         <a>toJSON()</a> or
         <a>toArrayBuffer()</a>
@@ -1420,26 +1444,26 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type <i>Text</i></td>
       <td>"text"</td>
       <td>"text/plain"</td>
-      <td data-link-for="NDEFRecord"><a>toText()</a></td>
+      <td><a>toText()</a></td>
     </tr>
     <tr>
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type <i>URI</i></td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td data-link-for="NDEFRecord"><a>toText()</a></td>
+      <td><a>toText()</a></td>
     </tr>
     <tr>
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type
           <i>Smart Poster</i></td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td data-link-for="NDEFRecord"><a>toText()</a></td>
+      <td><a>toText()</a></td>
     </tr>
     <tr>
       <td><a>Absolute-URL string</a> (<a>TNF</a>=3) record</td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td data-link-for="NDEFRecord"><a>toText()</a></td>
+      <td><a>toText()</a></td>
     </tr>
     <tr>
       <td><a>MIME type</a> (<a>TNF</a>=2) record with
@@ -1447,7 +1471,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       </td>
       <td>"json"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
-      <td data-link-for="NDEFRecord">
+      <td>
         <a>toText()</a> or
         <a>toJSON()</a> or
         <a>toArrayBuffer()</a>
@@ -1457,7 +1481,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <td><a>MIME type</a> (<a>TNF</a>=2) record</td>
       <td>"opaque"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
-      <td data-link-for="NDEFRecord">
+      <td>
         <a>toText()</a> or
         <a>toJSON()</a> or
         <a>toArrayBuffer()</a>
@@ -1468,7 +1492,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
         <code>urn:nfc:ext:w3.org:webnfc*</code></td>
       <td>"opaque"</td>
       <td>"application/octet-stream"</td>
-      <td data-link-for="NDEFRecord">
+      <td>
         <a>toText()</a> or
         <a>toJSON()</a> or
         <a>toArrayBuffer()</a>
@@ -1478,7 +1502,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <td>Any other <a>NDEF record</a> type</td>
       <td>"opaque"</td>
       <td>"application/octet-stream"</td>
-      <td data-link-for="NDEFRecord">
+      <td>
         <a>toText()</a> or
         <a>toJSON()</a> or
         <a>toArrayBuffer()</a>
@@ -3068,10 +3092,6 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 Let <var>header</var> be the first <a>byte</a> of <var>ndef</var>'s PAYLOAD field.
               </li>
               <li>
-                Let <var>charset</var> be <code>"utf-8"</code> if bit 7 (most significant bit) of
-                <var>header</var> is equal to the value 0, or else <code>"utf-16be"</code>.
-              </li>
-              <li>
                 Let <var>offset</var> be the value given by bit 5 to bit 0 of the
                 <var>header</var>.
               </li>
@@ -3094,18 +3114,8 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 the input.
               </li>
               <li>
-                Let <var>buffer</var> be the <a>byte sequence</a> of <var>
-                ndef</var>'s PAYLOAD field, from position <var>offset</var> + 1 to the end.
-              </li>
-              <li>
-                If <var>charset</var> is equal to <code>"utf-8"</code>,
-                set <var>record</var>'s associated <a>bytes</a> to <var>buffer</var>.
-              </li>
-              <li>
-                Otherwise, set the result of invoking <var>record</var>'s
-                <a href="#dom-ndefrecord-totext">toText()</a> method to the result of running
-                <a>decode</a> on <var>buffer</var> with <var>encoding</var> set
-                to <code>"utf-16be"</code>.
+                Set <var>record</var>'s associated <a>bytes</a> to the
+                <a>byte sequence</a> of <var>ndef</var>'s PAYLOAD field.
               </li>
             </ol>
             <p class="note">

--- a/index.html
+++ b/index.html
@@ -1276,8 +1276,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
             <li>
               If the <var>recordType</var> value is equal to <code>"json"</code> or
               <code>"opaque"</code>, then return an {{ArrayBuffer}} whose contents are the
-              <var>bytes</var>. Re-throw any exceptions thrown by the creation of the
-              {{ArrayBuffer}} object.
+              <var>bytes</var>. Re-throw any exceptions.
             </li>
             <li>
               Otherwise, return `null`.
@@ -1288,7 +1287,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
             <li>
               If the <var>recordType</var> value is equal to <code>"json"</code> or
               <code>"opaque"</code>, then return the result of running <a>parse JSON from bytes</a>
-              on <var>bytes</var>. Re-throw any exceptions thrown by <a>parse JSON from bytes</a>.
+              on <var>bytes</var>. Re-throw any exceptions.
             </li>
             <li>
               Otherwise, return `null`.

--- a/index.html
+++ b/index.html
@@ -287,6 +287,7 @@
     are defined in [[!DOM]].
   </p>
   <p>
+    <dfn data-cite="!ENCODING#concept-stream-push">push</dfn>,
     <dfn data-cite="!ENCODING#utf-8">UTF-8 encoding</dfn>,
     <dfn data-cite="!ENCODING#utf-8-decode">UTF-8 decode</dfn>,
     <dfn data-cite="!ENCODING#utf-8-encode">UTF-8 encode</dfn>,
@@ -698,17 +699,17 @@ reader.onreading = event => {
   for (let record of message.records) {
     switch (record.recordType) {
       case "text":
-        console.log(`Text: ${record.data()}`);
+        console.log(`Text: ${record.toText()}`);
         break;
       case "url":
-        console.log(`URL: ${record.data()}`);
+        console.log(`URL: ${record.toText()}`);
         break;
       case "json":
-        console.log(`JSON: ${record.data().myProperty.toString()}`);
+        console.log(`JSON: ${record.toJSON().myProperty.toString()}`);
         break;
       case "opaque":
         if (record.mediaType.startsWith('image/') {
-          const blob = new Blob([record.data()], {type: record.mediaType});
+          const blob = new Blob([record.toArrayBuffer()], {type: record.mediaType});
 
           const img = document.createElement("img");
           img.src = URL.createObjectURL(blob);
@@ -770,8 +771,8 @@ const reader = new NFCReader({url: document.baseURI, recordType: "json"});
 
 reader.addEventListener("reading", event => {
   for (let record of event.message.records) {
-    let article =/[aeio]/.test(record.data().title) ? "an" : "a";
-    console.log(`${record.data().name} is ${article} ${record.data().title}`);
+    let article =/[aeio]/.test(record.toJSON().title) ? "an" : "a";
+    console.log(`${record.toJSON().name} is ${article} ${record.toJSON().title}`);
   }
 });
 
@@ -812,7 +813,7 @@ reader.onreading = event => {
   for (let record of event.message.records) {
     console.log("Record type:  " + record.recordType);
     console.log("MIME type:    " + record.mediaType);
-    console.log("=== data ===\n" + record.data());
+    console.log("=== data ===\n" + record.toText());
   }
 };
 reader.start();
@@ -1189,7 +1190,9 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       interface NDEFRecord {
         readonly attribute NDEFRecordType recordType;
         readonly attribute USVString mediaType;
-        NDEFRecordData data();
+        [NewObject] USVString toText();
+        [NewObject] ArrayBuffer toArrayBuffer();
+        [NewObject] any toJSON();
       };
 
       dictionary NDEFRecordInit {
@@ -1198,6 +1201,12 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
         NDEFRecordData data;
       };
     </pre>
+    <p>
+      <a>NDEFRecord</a> objects have an associated <dfn id="ndefrecord-bytes">bytes</dfn>
+      (a <a>byte sequence</a>) set on creation that represents the payload data of the
+      <a>NDEF record</a>, which is <code>null</code> if there was no data in the
+      <a>NDEF record</a>.
+    </p>
     <p>
       The <dfn>NDEFRecordData</dfn> is a union type representing data types allowed
       for <a href="#dom-ndefrecordinit-data">NDEFRecordInit.data</a> property.
@@ -1212,9 +1221,18 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <a>NDEF record</a> types.
     </p>
     <p>
-      The <dfn>NDEFRecord.data()</dfn> method returns the
-      payload data of the <a>NDEF record</a> with an appropriate [[!ECMAScript]]
-      type, which depends on the <a>MIME type</a>.
+      The <dfn>NDEFRecord.toText()</dfn> method, when invoked, MUST return the
+      result of running <a>convert an NDEFRecord object's bytes</a> with <i>text</i>,
+      unless there's other specific illustration in step 7 of
+      <a href="#the-nfc-reading-algorithm">The NFC reading algorithm</a>.
+    </p>
+    <p>
+      The <dfn>NDEFRecord.toArrayBuffer()</dfn> method, when invoked, MUST return the
+      result of running <a>convert an NDEFRecord object's bytes</a> with <i>arrayBuffer</i>.
+    </p>
+    <p>
+      The <dfn>NDEFRecord.toJSON()</dfn> method, when invoked, MUST return the
+      result of running <a>convert an NDEFRecord object's bytes</a> with <i>JSON</i>.
     </p>
     <p>
       The <dfn>NDEFRecordInit</dfn> dictionary is used to initialize an <a>NDEF record</a>
@@ -1226,6 +1244,52 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <a href="#steps-receiving">Receiving and parsing content</a>
       and <a>Writing or pushing content</a> sections.
     </p>
+    <p>
+      To <dfn>convert an NDEFRecord object's bytes</dfn> to a given <var>type</var>, run these steps:
+    </p>
+    <ol>
+      <li>Let <var>bytes</var> be the <a>NDEFRecord</a> object's associated <a>bytes</a>.
+      </li>
+      <li>Let <var>recordType</var> be the value of <a>NDEFRecord</a> object's recordType attribute.
+      </li>
+      <li>Switch on <var>type</var>:
+        <dl>
+          <dt>text</dt>
+          <ol>
+            <li>
+              If the <var>recordType</var> value is not equal to <code>"empty"</code>, then
+              return the result of running <a>UTF-8 decode</a> on the <var>bytes</var>.
+            </li>
+            <li>
+              Otherwise, return <code>null</code>.
+            </li>
+          </ol>
+          <dt>arrayBuffer</dt>
+          <ol>
+            <li>
+              If the <var>recordType</var> value is equal to <code>"json"</code> or
+              <code>"opaque"</code>, then return an {{ArrayBuffer}} whose contents are the
+              <var>bytes</var>. Exceptions thrown during the creation of the {{ArrayBuffer}}
+              object are re-thrown.
+            </li>
+            <li>
+              Otherwise, return <code>null</code>.
+            </li>
+          </ol>
+          <dt>JSON</dt>
+          <ol>
+            <li>
+              If the <var>recordType</var> value is equal to <code>"json"</code> or
+              <code>"opaque"</code>, then return the result of running <a>parse JSON from bytes</a>
+              on <var>bytes</var>. Re-throw any exceptions thrown by <a>parse JSON from bytes</a>.
+            </li>
+            <li>
+              Otherwise, return <code>null</code>.
+            </li>
+          </ol>
+        </dl>
+      </li>
+    </ol>
   </section> <!-- NDEFRecord dictionary -->
 
   <section data-dfn-for="NDEFRecordType">
@@ -1334,38 +1398,42 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <th>NDEF record type</th>
       <th>NDEFRecord recordType</th>
       <th>NDEFRecord mediaType</th>
-      <th>NDEFRecord data</th>
+      <th>NDEFRecord data getters</th>
     </tr>
     <tr>
       <td>Empty (<a>TNF</a>=0) record</td>
       <td>"empty"</td>
       <td>""</td>
-      <td><code>null</code></td>
+      <td>
+        <a href="#dom-ndefrecord-totext">toText()</a> or
+        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
+        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      </td>
     </tr>
     <tr>
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type <i>Text</i></td>
       <td>"text"</td>
       <td>"text/plain"</td>
-      <td><code>DOMString</code></td>
+      <td><a href="#dom-ndefrecord-totext">toText()</a></td>
     </tr>
     <tr>
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type <i>URI</i></td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td><code>DOMString</code></td>
+      <td><a href="#dom-ndefrecord-totext">toText()</a></td>
     </tr>
     <tr>
       <td>NFC Forum <a>well-known type</a> (<a>TNF</a>=1) record with type
           <i>Smart Poster</i></td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td><code>DOMString</code></td>
+      <td><a href="#dom-ndefrecord-totext">toText()</a></td>
     </tr>
     <tr>
       <td><a>Absolute-URL string</a> (<a>TNF</a>=3) record</td>
       <td>"url"</td>
       <td>"text/plain"</td>
-      <td><code>DOMString</code></td>
+      <td><a href="#dom-ndefrecord-totext">toText()</a></td>
     </tr>
     <tr>
       <td><a>MIME type</a> (<a>TNF</a>=2) record with
@@ -1374,28 +1442,41 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <td>"json"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
       <td>
-        <code>null</code> or <code>DOMString</code> or <code>Number</code> or
-        <code>Dictionary</code>
+        <a href="#dom-ndefrecord-totext">toText()</a> or
+        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
+        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
       </td>
     </tr>
     <tr>
       <td><a>MIME type</a> (<a>TNF</a>=2) record</td>
       <td>"opaque"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
-      <td><code>ArrayBuffer</code></td>
+      <td>
+        <a href="#dom-ndefrecord-totext">toText()</a> or
+        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
+        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      </td>
     </tr>
     <tr>
       <td>NFC Forum <a>external type</a> type (<a>TNF</a>=4) record with type other than
         <code>urn:nfc:ext:w3.org:webnfc*</code></td>
       <td>"opaque"</td>
       <td>"application/octet-stream"</td>
-      <td><code>ArrayBuffer</code></td>
+      <td>
+        <a href="#dom-ndefrecord-totext">toText()</a> or
+        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
+        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      </td>
     </tr>
     <tr>
       <td>Any other <a>NDEF record</a> type</td>
       <td>"opaque"</td>
       <td>"application/octet-stream"</td>
-      <td><code>ArrayBuffer</code></td>
+      <td>
+        <a href="#dom-ndefrecord-totext">toText()</a> or
+        <a href="#dom-ndefrecord-tojson">toJSON()</a> or
+        <a href="#dom-ndefrecord-toarraybuffer">toArrayBuffer()</a>
+      </td>
     </tr>
   </table>
   <p>
@@ -2198,7 +2279,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 <var>promise</var> with that exception and abort these steps.
               </li>
               <li>
-                Otherwise, if <var>record</'s recordType is <code>"url"</code>,
+                Otherwise, if <var>record</var>'s recordType is <code>"url"</code>,
                 then let <var>ndef</var> the be result of passing
                 <var>record</var> to <a>map a URL to NDEF</a>.
                 If this throws an exception, reject <var>promise</var> with that
@@ -3012,11 +3093,11 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
               </li>
               <li>
                 If <var>charset</var> is equal to <code>"utf-8"</code>,
-                set <var>record</var>'s data to the result of running
-                <a>UTF-8 decode</a> on <var>buffer</var>.
+                set <var>record</var>'s associated <a>bytes</a> to <var>buffer</var>.
               </li>
               <li>
-                Otherwise, set <var>record</var>'s data to the result of running
+                Otherwise, set the result of invoking <var>record</var>'s
+                <a href="#dom-ndefrecord-totext">toText()</a> method to the result of running
                 <a>decode</a> on <var>buffer</var> with <var>encoding</var> set
                 to <code>"utf-16be"</code>.
               </li>
@@ -3059,8 +3140,9 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 <var>ndef</var>'s PAYLOAD field.
               </li>
               <li>
-                If <var>prefix code</var> is not 0, then set <var>record</var>'s data
-                to the prefix <a>string</a> obtained from mapping the value of
+                If <var>prefix code</var> is not 0, then set <var>record</var>'s associated
+                <a>bytes</a> to the result of running <a>UTF-8 encode</a> on the
+                prefix <a>string</a> obtained from mapping the value of
                 <var>prefix code</var> to the URL prefix as specified in the
                 [[!NFC-STANDARDS]] URI Record Type Definition specification,
                 Section 3.2.2.
@@ -3070,8 +3152,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 ndef</var>'s PAYLOAD field from the second <a>byte</a> to the end.
               </li>
               <li>
-                Concat <var>record</var>'s data with the result of running
-                <a>UTF-8 decode</a> on <var>buffer</var>.
+                <a>Push</a> <var>buffer</var> to <var>record</var>'s associated <a>bytes</a>.
               </li>
             </ol>
           </li> <!-- parsing NDEF URL record -->
@@ -3079,8 +3160,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
             If <var>ndef</var>'s TNF field is 3 (<a>absolute-URL string</a>), then
             set <var>record</var>'s recordType to <code>"url"</code>,
             set <var>record</var>'s mediaType to <code>"text/plain"</code> and
-            set <var>record</var>'s data to the <a>string</a> converted from
-            <var>ndef</var>'s PAYLOAD field.
+            set <var>record</var>'s associated <a>bytes</a> to <var>ndef</var>'s PAYLOAD field.
           </li> <!-- parsing NDEF Absolute URI record -->
           <li>
             If <var>ndef</var>'s TFN field is 2 (<a>MIME type</a>), then run
@@ -3105,9 +3185,8 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                     the input.
                   </li>
                   <li>
-                    Set <var>record</var>'s data to the result of executing
-                    <a>parse JSON from bytes</a> on <var>ndef</var>'s PAYLOAD field.
-                    If an error is thrown, skip to the next <a>NDEF record</a>.
+                    Set <var>record</var>'s associated <a>bytes</a> to
+                    <var>ndef</var>'s PAYLOAD field.
                   </li>
                 </ol>
               </li>
@@ -3123,8 +3202,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                     the input.
                   </li>
                   <li>
-                    Set <var>record</var>'s data to a new <code>ArrayBuffer</code>
-                    object constructed from the <a>byte</a> sequence of
+                    Set <var>record</var>'s associated <a>bytes</a> to
                     <var>ndef</var>'s PAYLOAD field.
                   </li>
                 </ol>
@@ -3149,8 +3227,8 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 <code>"application/octet-stream"</code>.
               </li>
               <li>
-                Set <var>record</var>'s data to a new <code>ArrayBuffer</code>
-                object constructed from the <a>bytes</a> of <var>ndef</var>'s PAYLOAD field.
+                Set <var>record</var>'s associated <a>bytes</a> to
+                <var>ndef</var>'s PAYLOAD field.
               </li>
             </ol>
           </li> <!-- parsing NDEF External/Unknown record -->


### PR DESCRIPTION
```
USVString toText();
[NewObject] ArrayBuffer toArrayBuffer();
[NewObject] object toJSON();
```

- Define a concept named "bytes" for NDEFRecord object
aim to replace the "record's data" in NFC reading algorithm
as which was removed from spec.
- Add algorithm for converting the NDEFRecord object's
associated bytes to a given type for above getters.
- Update examples and miscs.