### PR TITLE
Throw TypeError instead of SyntaxError when parsing a URL fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -2543,7 +2543,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           </li>
           <li>
             If |urlRecord| is failure, [= exception/throw =] a
-            {{TypeError}} {{DOMException}} and abort these steps.
+            {{TypeError}} and abort these steps.
           </li>
           <li>
             Let |ndef| be the notation for the <a>NDEF record</a> to
@@ -2724,7 +2724,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           </li>
           <li>
             If |urlRecord| is failure, [= exception/throw =] a
-            {{TypeError}} {{DOMException}} and abort these steps.
+            {{TypeError}} and abort these steps.
           </li>
           <li>
             Return |id|.

--- a/index.html
+++ b/index.html
@@ -2543,7 +2543,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           </li>
           <li>
             If |urlRecord| is failure, [= exception/throw =] a
-            {{"SyntaxError"}} {{DOMException}} and abort these steps.
+            {{TypeError}} {{DOMException}} and abort these steps.
           </li>
           <li>
             Let |ndef| be the notation for the <a>NDEF record</a> to
@@ -2724,7 +2724,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           </li>
           <li>
             If |urlRecord| is failure, [= exception/throw =] a
-            {{"SyntaxError"}} {{DOMException}} and abort these steps.
+            {{TypeError}} {{DOMException}} and abort these steps.
           </li>
           <li>
             Return |id|.


### PR DESCRIPTION
Fixed #268


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/web-nfc/pull/270.html" title="Last updated on Aug 5, 2019, 7:08 AM UTC (67c8d06)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/270/8220627...Honry:67c8d06.html" title="Last updated on Aug 5, 2019, 7:08 AM UTC (67c8d06)">Diff</a>