### PR TITLE
Do not force to throw exception when request NFC adapter listening fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -1122,8 +1122,8 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
         <a data-lt="serialization of an origin">serialized origin</a>
         and the URL [= url/path =] of the <a>current settings object</a> when
         requesting the operation must be recorded in each sent <a>NDEF
-        message</a>'s <a>Web NFC record</a>.  For details see the <a>Writing
-        or pushing content</a> section.
+        message</a>'s <a>Web NFC record</a>.  For details see the
+        [[[#writing-or-pushing-content]]] section.
       </li>
       <li>
         When listening for and pushing <a>NFC content</a>,
@@ -2952,7 +2952,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 all <a>NFC adapter</a>s to listen to <a>NDEF message</a>s.
               </li>
               <li>
-                If the request fails, then
+                If the request fails, then the UA may run the following sub-steps:
                 <ol>
                   <li>
                     Let |e:DOMException| be the result of [= exception/create =] a


### PR DESCRIPTION
Not all UA will throw error if the request fails for the following step:

> If this is the first listener being set up,
then make a request to all NFC adapters to listen to NDEF messages.

Fixed #242


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/web-nfc/pull/271.html" title="Last updated on Aug 5, 2019, 7:24 AM UTC (ffd38a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/271/8220627...Honry:ffd38a2.html" title="Last updated on Aug 5, 2019, 7:24 AM UTC (ffd38a2)">Diff</a>