### PR TITLE
Fixed ABNF format error

### DIFF
--- a/index.html
+++ b/index.html
@@ -2763,9 +2763,9 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       <p>
         A <dfn>match pattern</dfn> is defined by the following ABNF:
         <pre>
-          match-pattern       = top-level-type-name <code>"/"</code> [ tree <code>"."</code> ] subtype-name [ <code>"+"</code> suffix ] [ <code>";"</code> parameters ]
-          top-level-type-name = <code>"*"</code> / &lt; VCHAR except <code>"/"</code> and <code>"*"</code> &gt;
-          subtype-name        = <code>"*"</code> / &lt; VCHAR except <code>"+"</code> &gt;
+          match-pattern       = top-level-type-name "/" [ tree "." ] subtype-name [ "+" suffix ] [ ";" parameters ]
+          top-level-type-name = "*" / &lt; VCHAR except "/" and "*" &gt;
+          subtype-name        = "*" / &lt; VCHAR except "+" &gt;
         </pre>
         A <a>match pattern</a> is a
         <a href="http://pubs.opengroup.org/onlinepubs/007904875/utilities/xcu_chap02.html#tag_02_13_03">


### PR DESCRIPTION
The special symbols will be automatically highlight in latest ReSpec,
so just remove the `<code>` would work.

Fixed #257


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/web-nfc/pull/274.html" title="Last updated on Aug 5, 2019, 10:24 AM UTC (e6cd793)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/274/489d6a3...Honry:e6cd793.html" title="Last updated on Aug 5, 2019, 10:24 AM UTC (e6cd793)">Diff</a>