### PR TITLE
Fixes #248

### DIFF
--- a/index.html
+++ b/index.html
@@ -3272,7 +3272,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
             If |ndef|'s <a>TNF field</a> is `3` (<a>absolute-URL record</a>), then
             set |record|'s recordType to "`url`",
             set |record|'s mediaType to "`text/plain`" and
-            set |record|'s associated <a>bytes</a> to |ndef|'s <a>PAYLOAD field</a>.
+            set |record|'s associated <a>bytes</a> to |ndef|'s <a>TYPE field</a>.
           </li> <!-- parsing NDEF Absolute URI record -->
           <li>
             If |ndef|'s <a>TNF field</a> is `2` (<a>MIME type record</a>), then run


### PR DESCRIPTION
URL is stored in TYPE field and not PAYLOAD field


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kenchris/web-nfc/pull/284.html" title="Last updated on Aug 7, 2019, 3:29 PM UTC (91ce700)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/284/cd40617...kenchris:91ce700.html" title="Last updated on Aug 7, 2019, 3:29 PM UTC (91ce700)">Diff</a>