### PR TITLE
Correct well-known TNF for the smart poster figure

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,16 +348,16 @@
       Smart poster embeds additional records inside its payload. Below you
       see an example embedding a text and a url record.
       <ndef-record
-        header="1,1,0,1,0,3 (WELL KNOWN)"
-        content="*,*,_,*,_,*"
+        header="1,1,0,1,0,1 (WELL KNOWN)"
+        content="*,*,_,'Sp' (0x53\, 0x70 following NFC binary encoding),_,*"
         short>
         <ndef-record slot="payload"
-          header="1,0,0,1,0,3 (WELL KNOWN)"
+          header="1,0,0,1,0,1 (WELL KNOWN)"
           content="TYPE LENGTH (1 byte),*,_,'T' (0x54 following NFC binary encoding),_,*"
           short noindices>
         </ndef-record>
         <ndef-record slot="payload"
-          header="0,1,0,1,0,3 (WELL KNOWN)"
+          header="0,1,0,1,0,1 (WELL KNOWN)"
           content="TYPE LENGTH (1 byte),*,_,'U' (0x55 following NFC binary encoding),_,*"
           short noindices>
         </ndef-record>

--- a/ndef-record.js
+++ b/ndef-record.js
@@ -65,7 +65,7 @@ export class NDEFRecord extends HTMLElement {
     super();
     
     const header = this.getAttribute('header').split(',');
-    const content = this.getAttribute('content').split(',');
+    const content = this.getAttribute('content').replace(/,/g, ';').replace(/\\;/g, ',').split(';');
     const short = this.getAttribute('short');
     const noindices = this.getAttribute('noindices');
     


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/web-nfc/pull/288.html" title="Last updated on Aug 9, 2019, 5:01 AM UTC (a51a3c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/288/71af3b2...Honry:a51a3c1.html" title="Last updated on Aug 9, 2019, 5:01 AM UTC (a51a3c1)">Diff</a>