### PR TITLE
It's just ASCII, not NFC specific

### DIFF
--- a/index.html
+++ b/index.html
@@ -349,16 +349,16 @@
       see an example embedding a text and a url record.
       <ndef-record
         header="1,1,0,1,0,1 (WELL KNOWN)"
-        content="*,*,_,'Sp' (0x53\, 0x70 following NFC binary encoding),_,*"
+        content="*,*,_,'Sp' (0x53 0x70),_,*"
         short>
         <ndef-record slot="payload"
           header="1,0,0,1,0,1 (WELL KNOWN)"
-          content="TYPE LENGTH (1 byte),*,_,'T' (0x54 following NFC binary encoding),_,*"
+          content="TYPE LENGTH (1 byte),*,_,'T' (0x54),_,*"
           short noindices>
         </ndef-record>
         <ndef-record slot="payload"
           header="0,1,0,1,0,1 (WELL KNOWN)"
-          content="TYPE LENGTH (1 byte),*,_,'U' (0x55 following NFC binary encoding),_,*"
+          content="TYPE LENGTH (1 byte),*,_,'U' (0x55),_,*"
           short noindices>
         </ndef-record>
       </ndef-record>
@@ -2615,8 +2615,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 Set the |ndefRecord|'s <a>TNF field</a> to `1` (<a>well-known type record</a>).
               </li>
               <li>
-                Set the |ndefRecord|'s <a>TYPE field</a> to "`T`"
-                (value 0x54 following NFC binary encoding).
+                Set the |ndefRecord|'s <a>TYPE field</a> to "`T`" (`0x54`).
               </li>
               <li>
                 Set the |ndefRecord|'s <a>PAYLOAD LENGTH field</a> to |length|.
@@ -2706,8 +2705,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
                 Set the |ndefRecord|'s <a>TNF field</a> to `1` (<a>well-known type record</a>).
               </li>
               <li>
-                Set the |ndefRecord|'s <a>TYPE field</a> to "`U`" (0x55
-                following NFC binary encoding).
+                Set the |ndefRecord|'s <a>TYPE field</a> to "`U`" (`0x55`).
               </li>
               <li>
                 Set the |ndefRecord|'s <a>PAYLOAD LENGTH field</a> to |length|.


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kenchris/web-nfc/pull/291.html" title="Last updated on Aug 9, 2019, 10:30 AM UTC (ce6f29c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/291/1551341...kenchris:ce6f29c.html" title="Last updated on Aug 9, 2019, 10:30 AM UTC (ce6f29c)">Diff</a>