### PR TITLE
Distinguish between NFC not available and not enabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -2126,6 +2126,12 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           <li>
             If there is no underlying <a>NFC Adapter</a>, or if a connection cannot
             be established, then reject |p| with a
+            {{"NotSupportedError"}} {{DOMException}}
+            and return |p|.
+          </li>
+          <li>
+            If the UA is not allowed to access the underlying <a>NFC Adapter</a>
+            (e.g. a user preference), then reject |p| with a
             {{"NotReadableError"}} {{DOMException}}
             and return |p|.
           </li>
@@ -3106,6 +3112,24 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
           <li>
             If there is no underlying <a>NFC Adapter</a>, or if a connection cannot
             be established, then
+            <ol>
+              <li>
+                Let |e| be the result of [= exception/create =] a
+                {{"NotSupportedError"}} {{DOMException}}.
+              </li>
+              <li>
+                <a>Fire an event</a> named "`error`" at |reader|
+                using <a>NFCErrorEvent</a> with its error attribute
+                initialized to |e|.
+              </li>
+              <li>
+                Return.
+              </li>
+            </ol>
+          </li>
+          <li>
+            If the UA is not allowed to access the underlying <a>NFC Adapter</a>
+            (e.g. a user preference), then
             <ol>
               <li>
                 Let |e| be the result of [= exception/create =] a


### PR DESCRIPTION
FIX https://github.com/w3c/web-nfc/issues/237


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/294.html" title="Last updated on Aug 13, 2019, 3:02 PM UTC (32ebcec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/294/acdd289...beaufortfrancois:32ebcec.html" title="Last updated on Aug 13, 2019, 3:02 PM UTC (32ebcec)">Diff</a>