### PR TITLE
Fix JS text string example

### DIFF
--- a/index.html
+++ b/index.html
@@ -656,15 +656,14 @@
   <aside title="Push a text string to either a tag or peer"
        class="example">
     <p>
-      Pushing a text string (like the serialized JSON below)
-      to any kind of device is straight forward. Options can
-      be left out, as they default to pushing to both tags and
-      peers.
+      Pushing a text string to any kind of device is straightforward. 
+      Options can be left out, as they default to pushing to both tags
+      and peers.
     </p>
     <pre class="highlight">
 const writer = new NFCWriter();
 writer.push(
-  { prop1: "value1", prop2: "value2" }
+  "Hello World"
 ).then(() => {
   console.log("Message pushed.");
 }).catch(error => {


### PR DESCRIPTION
Pushing JSON object is not supported (yet). This PR fixes the JS example associated.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/296.html" title="Last updated on Aug 14, 2019, 7:42 AM UTC (5f6f353)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/296/e265838...beaufortfrancois:5f6f353.html" title="Last updated on Aug 14, 2019, 7:42 AM UTC (5f6f353)">Diff</a>