### PR TITLE
The retval of toxxx() should be nullable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1254,9 +1254,9 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
         readonly attribute NDEFRecordType recordType;
         readonly attribute USVString mediaType;
 
-        USVString toText();
-        [NewObject] ArrayBuffer toArrayBuffer();
-        [NewObject] object toJSON();
+        USVString? toText();
+        [NewObject] ArrayBuffer? toArrayBuffer();
+        [NewObject] object? toJSON();
       };
 
       dictionary NDEFRecordInit {
@@ -3429,19 +3429,19 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
       |record:NDEFRecord|, run these steps:
       <ol class=algorithm>
         <li>
-          Let |MIME type| be the <a>MIME type</a>
+          Let |mimeType| be the <a>MIME type</a>
           returned by running <a>parse a MIME type</a>
           on |ndefRecord|'s <a>TYPE field</a>.
         </li>
         <li>
-          If |MIME type| is a <a>JSON MIME type</a>, then
+          If |mimeType| is a <a>JSON MIME type</a>, then
           <ol>
             <li>
               Set |record|'s recordType to "`json`".
             </li>
             <li>
               Set |record|'s mediaType to the result of
-              <a>serialize a MIME type</a> with |MIME type| as
+              <a>serialize a MIME type</a> with |mimeType| as
               the input.
             </li>
             <li>
@@ -3458,7 +3458,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
             </li>
             <li>
               Set |record|'s mediaType to the result of
-              <a>serialize a MIME type</a> with |MIME type| as
+              <a>serialize a MIME type</a> with |mimeType| as
               the input.
             </li>
             <li>


### PR DESCRIPTION
Fixed minor naming consistency issue for the parameters BTW


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/web-nfc/pull/298.html" title="Last updated on Aug 19, 2019, 6:15 AM UTC (0fcfcbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/298/a19ccf2...Honry:0fcfcbd.html" title="Last updated on Aug 19, 2019, 6:15 AM UTC (0fcfcbd)">Diff</a>