### PR TITLE
Change default compatibility value to `any`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1944,7 +1944,7 @@ writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
         unrestricted double timeout = Infinity;
         boolean ignoreRead = true;
         AbortSignal? signal;
-        NDEFCompatibility compatibility = "nfc-forum";
+        NDEFCompatibility compatibility = "any";
       };
     </pre>
     <p>


### PR DESCRIPTION
I feel like having default compatibility value to `any` will help web developers getting started with the API as they may not know what means `nfc-forum` or `vendor`.

What do you think?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/299.html" title="Last updated on Aug 19, 2019, 11:41 AM UTC (36e1dfa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/299/95ff627...beaufortfrancois:36e1dfa.html" title="Last updated on Aug 19, 2019, 11:41 AM UTC (36e1dfa)">Diff</a>