### PR TITLE
Add AbortController example for NFCReader.scan()

### DIFF
--- a/index.html
+++ b/index.html
@@ -855,6 +855,29 @@ const writer = new NFCWriter();
 writer.push("Pushing data is fun!", {target: "tag", ignoreRead: false});
     </pre>
   </aside>
+
+  <aside title="Stop listening to NDEF messages" class="example">
+    <p>
+      Read NDEF messages for 3 seconds by using <a
+      href="#dom-nfcscanoptions-signal">signal</a> in the <a>NFCScanOptions</a>.
+    </p>
+    <pre class="highlight">
+const reader = new NFCReader();
+reader.onreading = event => {
+  console.log("NDEF message read."); 
+};
+
+const controller = new AbortController();
+controller.signal.onabort = event => {
+  console.log("We're done waiting for NDEF messages.");
+};
+
+reader.scan({ signal: controller.signal });
+
+// Stop listening to NDEF messages after 3s.
+setTimeout(() => controller.abort(), 3000);
+    </pre>
+  </aside>
   </section> <!-- Usage examples -->
 
   <section class="informative"> <h3>Use Cases</h3>


### PR DESCRIPTION
This PR simply adds a JavaScript example for `NFCReader.scan()`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/302.html" title="Last updated on Aug 21, 2019, 10:49 AM UTC (3b52939)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/302/d61ba6e...beaufortfrancois:3b52939.html" title="Last updated on Aug 21, 2019, 10:49 AM UTC (3b52939)">Diff</a>