### PR TITLE
Do not require reading event to listen for NFC content

### DIFF
--- a/index.html
+++ b/index.html
@@ -2956,10 +2956,10 @@ setTimeout(() => controller.abort(), 3000);
 
   <section> <h3>Listening for content</h3>
     <p>
-      In order to receive <a>NFC content</a>, the client needs to attach an
-      event listener for the "`reading`" event on an
-      {{NFCReader}} instance and then activate it by calling
-      <a>NFCReader.scan()</a>.
+      To listen for <a>NFC content</a>, the client MUST activate an
+      {{NFCReader}} instance by calling <a>NFCReader.start()</a>. When attaching
+      an event listener for the "`reading`" event on it, <a>NFC content</a> is
+      accessible to the client.
     </p>
     <p>
       Each {{NFCReader}} can filter the <a>NFC content</a> based on


### PR DESCRIPTION
FIC https://github.com/w3c/web-nfc/issues/304


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/305.html" title="Last updated on Aug 22, 2019, 9:36 AM UTC (0a83f3f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/305/9ded2e9...beaufortfrancois:0a83f3f.html" title="Last updated on Aug 22, 2019, 9:36 AM UTC (0a83f3f)">Diff</a>