### PR TITLE
Remove deprecated url key in example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1112,7 +1112,6 @@
         const message = event.message;
         if (message.records[0].recordType == 'empty') {
           writer.push({
-            url: "/custom/path",
             records: [{ recordType: "text", data: 'Hello World' }]
           });
           return;


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/365.html" title="Last updated on Oct 10, 2019, 12:33 PM UTC (dc08794)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/365/caeacb1...beaufortfrancois:dc08794.html" title="Last updated on Oct 10, 2019, 12:33 PM UTC (dc08794)">Diff</a>