### PR TITLE
Rename toText, toJSON, and ToArrayBuffer NDEFRecord methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -1122,17 +1122,17 @@
         for (let record of message.records) {
           switch (record.recordType) {
             case "text":
-              console.log(`Text: ${record.toText()}`);
+              console.log(`Text: ${record.text()}`);
               break;
             case "url":
-              console.log(`URL: ${record.toText()}`);
+              console.log(`URL: ${record.text()}`);
               break;
             case "json":
-              console.log(`JSON: ${record.toJSON().myProperty}`);
+              console.log(`JSON: ${record.json().myProperty}`);
               break;
             case "opaque":
               if (record.mediaType.startsWith('image/')) {
-                const blob = new Blob([record.toArrayBuffer()], {type: record.mediaType});
+                const blob = new Blob([record.arrayBuffer()], {type: record.mediaType});
 
                 const img = document.createElement("img");
                 img.src = URL.createObjectURL(blob);
@@ -1192,7 +1192,7 @@
 
       reader.addEventListener("reading", event => {
         for (let record of event.message.records) {
-          const json = record.toJSON();
+          const json = record.json();
           const article =/[aeio]/.test(json.title) ? "an" : "a";
           console.log(`${json.name} is ${article} ${json.title}`);
         }
@@ -1235,7 +1235,7 @@
         for (let record of event.message.records) {
           console.log("Record type:  " + record.recordType);
           console.log("MIME type:    " + record.mediaType);
-          console.log("=== data ===\n" + record.toText());
+          console.log("=== data ===\n" + record.text());
         }
       };
       reader.scan();
@@ -1310,10 +1310,10 @@
         for (let record of socialPost.toRecords()) {
           switch (record.recordType) {
             case "text":
-              text = record.toText();
+              text = record.text();
               break;
             case "-act":
-              const buffer = record.toArrayBuffer();
+              const buffer = record.arrayBuffer();
               const view = new DataView(buffer);
               action = view.getUint8(0);
               break;
@@ -1615,9 +1615,9 @@
         readonly attribute USVString mediaType;
         readonly attribute USVString id;
 
-        USVString? toText();
-        [NewObject] ArrayBuffer? toArrayBuffer();
-        [NewObject] any toJSON();
+        USVString? text();
+        [NewObject] ArrayBuffer? arrayBuffer();
+        [NewObject] any json();
         sequence&lt;NDEFRecord&gt; toRecords();
       };
 
@@ -1692,15 +1692,15 @@
       </div>
     </p>
     <p>
-      The <dfn>toText()</dfn> method, when invoked, MUST return the result of
+      The <dfn>text()</dfn> method, when invoked, MUST return the result of
       running <a>convert NDEFRecord.[[\PayloadData]] bytes</a> with an <a>NDEFRecord</a> object and `text` target.
     </p>
     <p>
-      The <dfn>toArrayBuffer()</dfn> method, when invoked, MUST return the result of
+      The <dfn>arrayBuffer()</dfn> method, when invoked, MUST return the result of
       running <a>convert NDEFRecord.[[\PayloadData]] bytes</a> with an <a>NDEFRecord</a> object and `arrayBuffer` target.
     </p>
     <p>
-      The <dfn>toJSON()</dfn> method, when invoked, MUST return the result of
+      The <dfn>json()</dfn> method, when invoked, MUST return the result of
       running <a>convert NDEFRecord.[[\PayloadData]] bytes</a> with an <a>NDEFRecord</a> object and a `JSON` target.
     </p>
     <p>
@@ -1952,22 +1952,22 @@
       <td>"`empty`"</td>
       <td><i>empty</i></td>
       <td>
-        <a>toText()</a> or<br>
-        <a>toJSON()</a> or<br>
-        <a>toArrayBuffer()</a>
+        <a>text()</a> or<br>
+        <a>json()</a> or<br>
+        <a>arrayBuffer()</a>
       </td>
     </tr>
     <tr>
       <td><a>Well-known type</a> record with type "`T`"</td>
       <td>"`text`"</td>
       <td>"`text/plain`"</td>
-      <td><a>toText()</a></td>
+      <td><a>text()</a></td>
     </tr>
     <tr>
       <td><a>Well-known type</a> record with type "`U`"</td>
       <td>"`url`"</td>
       <td>"`text/plain`"</td>
-      <td><a>toText()</a></td>
+      <td><a>text()</a></td>
     </tr>
     <tr>
       <td><a>Well-known type</a> record with type "`Sp`"</td>
@@ -1975,14 +1975,14 @@
       <td>""</td>
       <td>
         <a>toRecords()</a> or<br>
-        <a>toArrayBuffer()</a>
+        <a>arrayBuffer()</a>
       </td>
     </tr>
     <tr>
       <td><a>Absolute-URL record</a></td>
       <td>"`url`"</td>
       <td>"`text/plain`"</td>
-      <td><a>toText()</a></td>
+      <td><a>text()</a></td>
     </tr>
     <tr>
       <td><a>MIME type record</a> with
@@ -1991,9 +1991,9 @@
       <td>"`json`"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
       <td>
-        <a>toText()</a> or<br>
-        <a>toJSON()</a> or<br>
-        <a>toArrayBuffer()</a>
+        <a>text()</a> or<br>
+        <a>json()</a> or<br>
+        <a>arrayBuffer()</a>
       </td>
     </tr>
     <tr>
@@ -2001,9 +2001,9 @@
       <td>"`opaque`"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
       <td>
-        <a>toText()</a> or<br>
-        <a>toJSON()</a> or<br>
-        <a>toArrayBuffer()</a>
+        <a>text()</a> or<br>
+        <a>json()</a> or<br>
+        <a>arrayBuffer()</a>
       </td>
     </tr>
     <tr>
@@ -2011,9 +2011,9 @@
       <td><a>external type</a></td>
       <td>"`application/octet-stream`"</td>
       <td>
-        <a>toText()</a> or<br>
-        <a>toJSON()</a> or<br>
-        <a>toArrayBuffer()</a>
+        <a>text()</a> or<br>
+        <a>json()</a> or<br>
+        <a>arrayBuffer()</a>
       </td>
     </tr>
     <tr>
@@ -2021,9 +2021,9 @@
       <td>"`opaque`"</td>
       <td>"`application/octet-stream`"</td>
       <td>
-        <a>toText()</a> or<br>
-        <a>toJSON()</a> or<br>
-        <a>toArrayBuffer()</a>
+        <a>text()</a> or<br>
+        <a>json()</a> or<br>
+        <a>arrayBuffer()</a>
       </td>
     </tr>
   </table>


### PR DESCRIPTION
This PR renames NDEFRecord methods "toText()" to "text()", "toJSON()" to
"json()", and "toArrayBuffer()", to "arrayBuffer()" as discussed in https://github.com/w3c/web-nfc/issues/366.

Note that `toRecords` seems off now. Should it be renamed to `getRecords()`?

For info, I didn't update Note in https://w3c.github.io/web-nfc/#mapping-json-to-ndef.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/370.html" title="Last updated on Oct 11, 2019, 2:40 PM UTC (b78d8bf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/370/6818b06...beaufortfrancois:b78d8bf.html" title="Last updated on Oct 11, 2019, 2:40 PM UTC (b78d8bf)">Diff</a>