### PR TITLE
Don't restrict toArrayBuffer to json and opaque records

### DIFF
--- a/index.html
+++ b/index.html
@@ -1770,12 +1770,8 @@
           <dt>arrayBuffer</dt>
           <ol>
             <li>
-              If the |recordType| value is equal to "`json`" or "`opaque`", then
-              return an {{ArrayBuffer}} whose contents are the
-              |bytes|. Re-[= exception/throw =] any exceptions.
-            </li>
-            <li>
-              Otherwise, return `null`.
+              Return an {{ArrayBuffer}} whose contents are the |bytes|.
+              Re-[= exception/throw =] any exceptions.
             </li>
           </ol>
           <dt>JSON</dt>


### PR DESCRIPTION
If https://github.com/w3c/web-nfc/issues/371 gets accepted, this PR fixes https://github.com/w3c/web-nfc/issues/371


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/372.html" title="Last updated on Oct 14, 2019, 9:45 AM UTC (775f896)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/372/6818b06...beaufortfrancois:775f896.html" title="Last updated on Oct 14, 2019, 9:45 AM UTC (775f896)">Diff</a>