### PR TITLE
Add data attribute to NDEFRecord

### DIFF
--- a/index.html
+++ b/index.html
@@ -1614,6 +1614,7 @@
         readonly attribute NDEFRecordType recordType;
         readonly attribute USVString mediaType;
         readonly attribute USVString id;
+        readonly attribute DataView? data;
 
         USVString? text();
         [NewObject] ArrayBuffer? arrayBuffer();
@@ -1690,6 +1691,9 @@
         instead of <a>record identifier</a>, but the identifier is tied to each record and not
         the message (collection of records), and it may be present when no payload is.
       </div>
+    </p>
+    <p>
+      The <dfn>data</dfn> property represents the <a>[[\PayloadData]]</a> bytes of the <a>NDEF Record</a>.
     </p>
     <p>
       The <dfn>text()</dfn> method, when invoked, MUST return the result of


### PR DESCRIPTION
This PR simply adds the `data` attribute to NDEFRecord as discussed in https://github.com/w3c/web-nfc/issues/366#issuecomment-542104572

Note that this PR is part of a bigger spec change. Don't merge until we all agree.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/377.html" title="Last updated on Oct 16, 2019, 1:55 PM UTC (4da9f65)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/377/d1416bd...beaufortfrancois:4da9f65.html" title="Last updated on Oct 16, 2019, 1:55 PM UTC (4da9f65)">Diff</a>