### PR TITLE
s/ArrayBuffer/BufferSource/g in NDEFRecordInit data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1986,7 +1986,7 @@
     <tr>
       <td><dfn>"`media`"</dfn></td>
       <td>[= MIME type =]</a></td>
-      <td>{{ArrayBuffer}}</td>
+      <td>{{BufferSource}}</td>
       <td><a>MIME type record</a> (TNF=2) with TYPE= [= MIME type =]</td>
     </tr>
     <tr>
@@ -1999,8 +1999,7 @@
       <td><i>[= external type =]</i></td>
       <td><i>unused</i></td>
       <td>
-        {{ArrayBuffer}} or any<br>
-        <a>typed array type</a> or<br>
+        {{BufferSource}} or<br>
         {{NDEFMessage}}
       </td>
       <td><a>External type record</a> (TNF=4) with TYPE= [= external type =]</td>
@@ -2009,8 +2008,7 @@
       <td><i>[= local type =]</i></td>
       <td><i>unused</i></td>
       <td>
-        {{ArrayBuffer}} or any<br>
-        <a>typed array type</a>
+        {{BufferSource}}
       </td>
       <td><a>External type record</a> (TNF=4) with TYPE= [= local type =] inside
         the <a>NDEFMessage</a> payload of another record</td>
@@ -2018,7 +2016,7 @@
     <tr>
       <td><dfn>"`unknown`"</dfn></td>
       <td><i>unused</i></td>
-      <td>{{ArrayBuffer}}</td>
+      <td>{{BufferSource}}</td>
       <td><a>unknown record</a> (TNF=5)</td>
     </tr>
   </table>
@@ -2124,7 +2122,7 @@
   <a>NDEF message</a>s either from an <a>NFC tag</a> or an
   <a>NFC peer</a>.
   <pre class="idl">
-    typedef (DOMString or ArrayBuffer or NDEFMessageInit) NDEFMessageSource;
+    typedef (DOMString or BufferSource or NDEFMessageInit) NDEFMessageSource;
 
     [SecureContext, Exposed=Window]
     interface NFCWriter {
@@ -3314,8 +3312,8 @@
         run these steps:
         <ol class=algorithm>
           <li>
-            If the type of a |record|'s data is not an
-            {{ArrayBuffer}}, [= exception/throw =] a {{TypeError}}
+            If the type of a |record|'s data is not a
+            {{BufferSource}}, [= exception/throw =] a {{TypeError}}
             and abort these steps.
           </li>
           <li>
@@ -3370,8 +3368,8 @@
         run these steps:
         <ol class=algorithm>
           <li>
-            If the type of a |record|'s data is not an
-            {{ArrayBuffer}}, [= exception/throw =] a {{TypeError}}
+            If the type of a |record|'s data is not a
+            {{BufferSource}}, [= exception/throw =] a {{TypeError}}
             and abort these steps.
           </li>
           <li>
@@ -3414,8 +3412,8 @@
         run these steps:
         <ol class=algorithm>
           <li>
-            If the type of a |record|'s data is not an
-            {{ArrayBuffer}}, [= exception/throw =] a {{TypeError}}
+            If the type of a |record|'s data is not a
+            {{BufferSource}}, [= exception/throw =] a {{TypeError}}
             and abort these steps.
           </li>
           <li>


### PR DESCRIPTION
This PR replaces the ArrayBuffer to BufferSource in NDEFRecordInit data as discussed in https://github.com/w3c/web-nfc/issues/366#issuecomment-542104572

Since GitHub doesn't support dependencies between PR, this one sits on top of https://github.com/w3c/web-nfc/pull/380

Please check out only the commit: https://github.com/w3c/web-nfc/commit/68f4875493736347db0726b67ef5affbb12cde44 for now

Do not merge until https://github.com/w3c/web-nfc/pull/380 is merged


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/382.html" title="Last updated on Oct 17, 2019, 3:11 PM UTC (1524418)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/382/3f8af55...beaufortfrancois:1524418.html" title="Last updated on Oct 17, 2019, 3:11 PM UTC (1524418)">Diff</a>