### PR TITLE
Remove text(), json(), and arrayBuffer()

### DIFF
--- a/index.html
+++ b/index.html
@@ -1757,9 +1757,8 @@
         <a data-link-for="NDEFRecord">recordType</a> attribute.
       </li>
       <li>
-        If the |recordType| value is "`smart-poster`", or "`media`", or
-        an <a>external type</a>, then return the result of running
-        <a>parse records from bytes</a> on |bytes|.
+        If the |recordType| value is "`smart-poster`", an <a>external type</a>,
+        then return the result of running <a>parse records from bytes</a> on |bytes|.
         Re-[= exception/throw =] any exceptions.
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -1762,7 +1762,8 @@
         Re-[= exception/throw =] any exceptions.
       </li>
       <li>
-        Otherwise, return `null`.
+        Otherwise, [= exception/throw =] a
+        {{"NotSupportedError"}} {{DOMException}} and abort these steps.
       </li>
     </ol>
   </section> <!-- NDEFRecord dictionary -->

--- a/index.html
+++ b/index.html
@@ -1111,21 +1111,22 @@
           return;
         }
 
+        const decoder = new TextDecoder();
         for (const record of message.records) {
           switch (record.recordType) {
             case "text":
-              console.log(`Text: ${record.text()}`);
+              const textDecoder = new TextDecoder(record.encoding);
+              console.log(`Text: ${textDecoder.decode(record.data)} (${record.lang})`);
               break;
             case "url":
-              console.log(`URL: ${record.text()}`);
+              console.log(`URL: ${decoder.decode(record.data)}`);
               break;
             case "media":
               if (record.mediaType === "application/json") {
-                const decoder = new TextDecoder();
                 console.log(`JSON: ${JSON.parse(decoder.decode(record.data))}`);
               }
               else if (record.mediaType.startsWith('image/')) {
-                const blob = new Blob([record.arrayBuffer()], {type: record.mediaType});
+                const blob = new Blob([record.data], {type: record.mediaType});
 
                 const img = document.createElement("img");
                 img.src = URL.createObjectURL(blob);
@@ -1237,10 +1238,11 @@
       const reader = new NFCReader();
       reader.scan();
       reader.onreading = event => {
+        const decoder = new TextDecoder();
         for (const record of event.message.records) {
           console.log("Record type:  " + record.recordType);
           console.log("MIME type:    " + record.mediaType);
-          console.log("=== data ===\n" + record.text());
+          console.log("=== data ===\n" + decoder.decode(record.data));
         }
       };
 
@@ -1339,15 +1341,14 @@
         let action;
         let text = "";
 
+        const decoder = new TextDecoder();
         for (let record of socialPost.toRecords()) {
           switch (record.recordType) {
             case "text":
-              text = record.text();
+              text = decoder.decode(record.data);
               break;
             case "act":
-              const buffer = record.arrayBuffer();
-              const view = new DataView(buffer);
-              action = view.getUint8(0);
+              action = record.data.getUint8(0);
               break;
           }
         }
@@ -1612,9 +1613,6 @@
         readonly attribute USVString? encoding;
         readonly attribute USVString? lang;
 
-        USVString? text();
-        [NewObject] ArrayBuffer? arrayBuffer();
-        [NewObject] any json();
         sequence&lt;NDEFRecord&gt; toRecords();
       };
 
@@ -1719,20 +1717,8 @@
       The <dfn>data</dfn> property represents the <a>[[\PayloadData]]</a> bytes of the <a>NDEF Record</a>.
     </p>
     <p>
-      The <dfn>text()</dfn> method, when invoked, MUST return the result of
-      running <a>convert NDEFRecord.[[\PayloadData]] bytes</a> with an <a>NDEFRecord</a> object and `text` target.
-    </p>
-    <p>
-      The <dfn>arrayBuffer()</dfn> method, when invoked, MUST return the result of
-      running <a>convert NDEFRecord.[[\PayloadData]] bytes</a> with an <a>NDEFRecord</a> object and `arrayBuffer` target.
-    </p>
-    <p>
-      The <dfn>json()</dfn> method, when invoked, MUST return the result of
-      running <a>convert NDEFRecord.[[\PayloadData]] bytes</a> with an <a>NDEFRecord</a> object and a `JSON` target.
-    </p>
-    <p>
       The <dfn>toRecords()</dfn> method, when invoked, MUST return the result of
-      running <a>convert NDEFRecord.[[\PayloadData]] bytes</a> with an <a>NDEFRecord</a> object and `records` target.
+      running <a>convert NDEFRecord.[[\PayloadData]] bytes</a> with the <a>NDEF Record</a>.
     </p>
     <p data-dfn-for="NDEFRecordInit">
       The <dfn>NDEFRecordInit</dfn> dictionary is used to initialize an <a>NDEF record</a>
@@ -1759,7 +1745,8 @@
       [[[#steps-receiving]]] and [[[#writing-or-pushing-content]]] sections.
     </p>
     <p>
-      To <dfn>convert NDEFRecord.[[\PayloadData]] bytes</dfn>, pass a |record:NDEFRecord| and a |target|, run these steps:
+      To <dfn>convert NDEFRecord.[[\PayloadData]] bytes</dfn>
+      given a |record:NDEFRecord|, run these steps:
     </p>
     <ol class=algorithm>
       <li>
@@ -1769,76 +1756,14 @@
         Let |recordType:record type| be the value of |record|'s
         <a data-link-for="NDEFRecord">recordType</a> attribute.
       </li>
-      <li>Switch on |target|:
-        <dl>
-          <dt>text</dt>
-          <ol>
-            <li>
-              If the |recordType| value is equal to "`empty`", return `null`.
-            </li>
-            <li>
-              If the |recordType| value is equal to "`text`", then run the following sub-steps:
-              <ol>
-                <li>
-                  Let |header| be the first <a>byte</a> of |bytes|.
-                </li>
-                <li>
-                  Let |charset| be "`utf-8`" if bit `7` (<a>MB field</a>) of
-                  |header| is equal to the value 0, or else "`utf-16be`".
-                </li>
-                <li>
-                  Let |offset| be the value given by bit `5` to bit `0` of the
-                  |header|.
-                </li>
-                <li>
-                  Let |buffer| be the |bytes|,
-                  from position |offset| + `1` to the end.
-                </li>
-                <li>
-                  If |charset| is equal to "`utf-8`", return the result of
-                  running <a>UTF-8 decode</a> on |buffer|.
-                </li>
-                <li>
-                  Otherwise, return the result of running <a>decode</a> on
-                  |buffer| with `encoding` set to "`utf-16be`".
-                </li>
-              </ol>
-            </li>
-            <li>
-              Otherwise, return the result of running <a>UTF-8 decode</a> on |bytes|.
-            </li>
-          </ol>
-          <dt>arrayBuffer</dt>
-          <ol>
-            <li>
-              Return an {{ArrayBuffer}} whose contents are the |bytes|.
-              Re-[= exception/throw =] any exceptions.
-            </li>
-          </ol>
-          <dt>JSON</dt>
-          <ol>
-            <li>
-              If the |recordType| value is equal to "`media`", then
-              return the result of running <a>parse JSON from bytes</a>
-              on |bytes|. Re-[= exception/throw =] any exceptions.
-            </li>
-            <li>
-              Otherwise, return `null`.
-            </li>
-          </ol>
-          <dt>records</dt>
-          <ol>
-            <li>
-              If the |recordType| value is "`smart-poster`", or "`media`", or
-              an <a>external type</a>, then return the result of running
-              <a>parse records from bytes</a> on |bytes|.
-              Re-[= exception/throw =] any exceptions.
-            </li>
-            <li>
-              Otherwise, return `null`.
-            </li>
-          </ol>
-        </dl>
+      <li>
+        If the |recordType| value is "`smart-poster`", or "`media`", or
+        an <a>external type</a>, then return the result of running
+        <a>parse records from bytes</a> on |bytes|.
+        Re-[= exception/throw =] any exceptions.
+      </li>
+      <li>
+        Otherwise, return `null`.
       </li>
     </ol>
   </section> <!-- NDEFRecord dictionary -->
@@ -2021,91 +1946,58 @@
   <p>
     The mapping from <a>NDEF record</a> types to <a>NDEFRecord</a>,
     as used for incoming <a>NDEF message</a>s described in the
-    [[[#steps-receiving]]] section, is as
-    follows. The data getters column shows the ones that should work for the
-    given payload type (the others may or will fail, depending on case).
+    [[[#steps-receiving]]] section, is as follows.
   </p>
   <table class="simple" data-link-for="NDEFRecord">
     <tr>
       <th>NDEF record <a>TNF field</a><br> and <a>TYPE field</a></th>
       <th>NDEFRecord<br> recordType</th>
       <th>NDEFRecord<br> mediaType</th>
-      <th>NDEFRecord<br> data getters</th>
     </tr>
     <tr>
       <td><a>Empty record</a> (TNF=0)</td>
       <td>"`empty`"</td>
       <td>""</td>
-      <td><i>none</i> (all getters fail)</td>
     </tr>
     <tr>
       <td><a>Well-known type</a> (TNF=1) record with TYPE="`T`"</td>
       <td>"`text`"</td>
       <td>"`text/plain`"</td>
-      <td><a>text()</a> or <a>json()</a> or <a>arrayBuffer()</a></a></td>
     </tr>
     <tr>
       <td><a>Well-known type</a> (TNF=1) record with TYPE="`U`"</td>
       <td>"`url`"</td>
       <td>"`text/plain`"</td>
-      <td><a>text()</a> or <a>json()</a> or <a>arrayBuffer()</a></a></td>
     </tr>
     <tr>
       <td><a>Well-known type</a> (TNF=1) record with TYPE="`Sp`"</td>
       <td>"`smart-poster`"</td>
       <td>""</td>
-      <td>
-        <a>toRecords()</a> or<br>
-        <a>arrayBuffer()</a>
-      </td>
     </tr>
     <tr>
       <td><a>MIME type record</a> (TNF=2) with TYPE=<a>MIME type</a></td>
       <td>"`media`"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
-      <td>
-        <a>text()</a> or<br>
-        <a>json()</a> or<br>
-        <a>arrayBuffer()</a>
-      </td>
     </tr>
     <tr>
       <td><a>Absolute-URL record</a> (TNF=3) with TYPE=<i>url</i></td>
       <td>"`url`"</td>
       <td>""</td>
-      <td>
-        <a>text()</a> returning <i>url</i> or<br>
-        <a>arrayBuffer()</a>
-      </td>
     </tr>
     <tr>
       <td><a>External type record</a> (TNF=4) with TYPE=<a>external type</a></td>
       <td><a>external type</a></td>
       <td>"`application/octet-stream`"</td>
-      <td>
-        <a>text()</a> or<br>
-        <a>json()</a> or<br>
-        <a>arrayBuffer()</a> or<br>
-        <a>toRecords()</a>
-      </td>
     </tr>
     <tr>
       <td>Any embedded <a>NDEF record</a> with TYPE=<a>local type</a></td>
       <td><a>local type</a></td>
       <td>"`application/octet-stream`"</td>
-      <td>
-        <a>text()</a> or<br>
-        <a>json()</a> or<br>
-        <a>arrayBuffer()</a>
-      </td>
     </tr>
     <tr>
       <td><a>Unknown record</a> (TNF=5)</td>
       <td>"`unknown`"</td>
       <td>"`application/octet-stream`"</td>
-      <td>
-        <a>arrayBuffer()</a>
-      </td>
     </tr>
   </table>
   </section>


### PR DESCRIPTION
As discussed in https://github.com/w3c/web-nfc/issues/366#issuecomment-542104572, this PR removes ` text()`, `json()`, and `arrayBuffer()` methods from NDEDRecord as we have now `data` attribute.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/384.html" title="Last updated on Oct 18, 2019, 8:25 AM UTC (58afbef)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/384/8c6264d...beaufortfrancois:58afbef.html" title="Last updated on Oct 18, 2019, 8:25 AM UTC (58afbef)">Diff</a>