### PR TITLE
Don't wrap smart-poster and absolute-url in tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -1901,7 +1901,7 @@
       <td><a>Well-known type</a> (TNF=1) record with TYPE="`U`"</td>
     </tr>
     <tr>
-      <td><dfn>"`smart-poster`"</dfn></td>
+      <td nowrap><dfn>"`smart-poster`"</dfn></td>
       <td><i>unused</i></td>
       <td>{{NDEFMessage}}</td>
       <td><a>Well-known type</a> (TNF=1) record with TYPE="`Sp`"</td>
@@ -1913,7 +1913,7 @@
       <td><a>MIME type record</a> (TNF=2) with TYPE= [= MIME type =]</td>
     </tr>
     <tr>
-      <td><dfn>"`absolute-url`"</dfn></td>
+      <td nowrap><dfn>"`absolute-url`"</dfn></td>
       <td><i>unused</i></td>
       <td>{{DOMString}} <i>url</i></td>
       <td><a>Absolute-URL record</a> (TNF=3) with TYPE=<i>url</i></td>
@@ -1971,7 +1971,7 @@
     </tr>
     <tr>
       <td><a>Well-known type</a> (TNF=1) record with TYPE="`Sp`"</td>
-      <td>"`smart-poster`"</td>
+      <td nowrap>"`smart-poster`"</td>
       <td>""</td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR makes sure "smart-poster" and "absolute-url" strings are not wrapped in tables to ease reading.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/386.html" title="Last updated on Oct 18, 2019, 8:39 AM UTC (323ac66)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/386/44527d0...beaufortfrancois:323ac66.html" title="Last updated on Oct 18, 2019, 8:39 AM UTC (323ac66)">Diff</a>