### PR TITLE
Remove "API" in title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>Web NFC API</title>
+  <title>Web NFC</title>
   <meta charset="UTF-8">
   <script type=module src="ndef-record.js"></script>
   <script src='https://www.w3.org/Tools/respec/respec-w3c' async class=


### PR DESCRIPTION
Web API specs don't have "API" in their title usually, hence removing it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/pull/404.html" title="Last updated on Oct 23, 2019, 6:27 AM UTC (d064224)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/404/b594ad4...d064224.html" title="Last updated on Oct 23, 2019, 6:27 AM UTC (d064224)">Diff</a>