### PR TITLE
Accept BufferSource data for text records

### DIFF
--- a/index.html
+++ b/index.html
@@ -1906,7 +1906,10 @@
     <tr>
       <td><dfn>"`text`"</dfn></td>
       <td><i>unused</i></td>
-      <td>{{DOMString}}</td>
+      <td>
+        {{BufferSource}} or<br>
+        {{DOMString}}
+      </td>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`T`"</td>


### PR DESCRIPTION
To push UTF-16 content, data in text records must accept BufferSource.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/406.html" title="Last updated on Oct 23, 2019, 2:26 PM UTC (74277e5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/406/3b7b7b4...beaufortfrancois:74277e5.html" title="Last updated on Oct 23, 2019, 2:26 PM UTC (74277e5)">Diff</a>