### PR TITLE
Added precision to local types

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,8 +564,9 @@
             NFC Forum <dfn>local type</dfn> that are defined by the NFC Forum or
             by an application, within the scope of the local context of another
             record or application and always start with lowercase letter or a
-            number. See <a>Smart poster</a> for an example on how local types are
-            used.
+            number. Those are usually short to save on potentially long domain-name
+            containing record types. See <a>Smart poster</a> for an example on
+            how local types are used.
           </p>
           <p class=note>
             A [=local type=] is thus defined in terms of a containing record type,

--- a/index.html
+++ b/index.html
@@ -562,11 +562,12 @@
         <li>
           <p>
             NFC Forum <dfn>local type</dfn> that are defined by the NFC Forum or
-            by an application, within the scope of the local context of another
-            record or application and always start with lowercase letter or a
-            number. Those are usually short to save on potentially long domain-name
-            containing record types. See <a>Smart poster</a> for an example on
-            how local types are used.
+            by an application, and always start with lowercase letter or a
+            number. Those are usually short strings that are unique only within
+            the local context of the containing record. They are used when types
+            meaning doesn't matter outside of the local context of the
+            containing record and when storage usage is a hard constraint. See
+            <a>Smart poster</a> for an example on how local types are used.
           </p>
           <p class=note>
             A [=local type=] is thus defined in terms of a containing record type,


### PR DESCRIPTION
As suggested in https://github.com/w3c/web-nfc/pull/411#issuecomment-545925744, this PR adds a precision to local types.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/412.html" title="Last updated on Oct 25, 2019, 12:26 PM UTC (f662aa4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/412/8970772...beaufortfrancois:f662aa4.html" title="Last updated on Oct 25, 2019, 12:26 PM UTC (f662aa4)">Diff</a>