### PR TITLE
ignore media type for anything but mime

### DIFF
--- a/index.html
+++ b/index.html
@@ -1203,7 +1203,6 @@
     <pre class="example">
       const reader = new NDEFReader();
       await reader.scan({
-        recordType: "mime",
         mediaType: "application/*json"
       });
       reader.onreading = event => {
@@ -2528,7 +2527,6 @@
         class="example highlight">
         const options = {
           id: "https://www.w3.org/*",  // any path from the domain is accepted
-          recordType: "mime",
           mediaType: "application/*json"  // any JSON-based MIME type
         }
       </pre>
@@ -2537,7 +2535,6 @@
         class="example highlight">
         const options = {
           id: "https://w3.org/info/restaurant/daily-menu/",
-          recordType: "mime",
           mediaType: "application/octet-stream"
         }
       </pre>

--- a/index.html
+++ b/index.html
@@ -1623,7 +1623,7 @@
         constructor(NDEFRecordInit recordInit);
 
         readonly attribute USVString recordType;
-        readonly attribute USVString mediaType;
+        readonly attribute USVString? mediaType;
         readonly attribute USVString id;
         readonly attribute DataView? data;
 
@@ -2008,35 +2008,35 @@
       <td>0</td>
       <td><i>unused</i></td>
       <td>"`empty`"</td>
-      <td>""</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`T`"</td>
       <td>"`text`"</td>
-      <td>"`text/plain`"</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`U`"</td>
       <td>"`url`"</td>
-      <td>"`text/plain`"</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`Sp`"</td>
       <td nowrap>"`smart-poster`"</td>
-      <td>""</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=Local type=] record*</td>
       <td>1</td>
       <td>[=local type name=]</td>
       <td>[=local type name=]</td>
-      <td>"`application/octet-stream`"</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=MIME type record=]</td>
@@ -2050,21 +2050,21 @@
       <td>3</td>
       <td>URL</td>
       <td>"`absolute-url`"</td>
-      <td>""</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=External type record=]</a></td>
       <td>4</td>
       <td>[=external type name=]</td>
       <td>[=external type name=]</td>
-      <td>"`application/octet-stream`"</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td><a>Unknown record</a></td>
       <td>5</td>
       <td><i>unused</i></td>
       <td>"`unknown`"</td>
-      <td>"`application/octet-stream`"</td>
+      <td>`null`</td>
     </tr>
   </table>
   </section>
@@ -3037,21 +3037,6 @@
             [= exception/throw =] a {{TypeError}} and abort these steps.
           </li>
           <li>
-            Let |mimeTypeRecord| be the <a>MIME type</a>
-            returned by running <a>parse a MIME type</a> on
-            |record|'s mediaType.
-            <ol>
-              <li>
-                If |mimeTypeRecord| is failure, let |mimeTypeRecord| be a new
-                <a>MIME type record</a> whose type is "`text`", and subtype is "`plain`".
-              </li>
-              <li>
-                If |mimeTypeRecord|'s type is not "`text`", then [= exception/throw =] a
-                {{"SyntaxError"}} {{DOMException}} and abort these steps.
-              </li>
-            </ol>
-          </li>
-          <li>
             Let |documentLanguage:string| be the [=document element=]'s lang attribute.
           </li>
           <li>
@@ -3258,16 +3243,6 @@
             If the type of a |record|'s data is not a
             {{BufferSource}}, [= exception/throw =] a {{TypeError}}
             and abort these steps.
-          </li>
-          <li>
-            Let |mimeTypeRecord| be the <a>MIME type</a>
-            returned by running <a>parse a MIME type</a> on |record|'s mediaType.
-            <ol>
-              <li>
-                If |mimeTypeRecord| is failure, let |mimeTypeRecord| be a new
-                <a>MIME type record</a> whose type is "`application`", and subtype is "`octet-stream`".
-              </li>
-            </ol>
           </li>
           <li>
             Set |arrayBuffer| to |record|'s data.
@@ -3952,7 +3927,7 @@
       </li>
       <li>
         If |ndef|'s |typeNameField:number| is `0` (<a>empty record</a>), then set
-        |record|'s recordType to "`empty`" and set |record|'s mediaType to `""`.
+        |record|'s recordType to "`empty`".
       </li>
       <li>
         If |ndef|'s |typeNameField| is `1` ([=well-known type record=]):
@@ -4023,8 +3998,8 @@
         equal to an empty ordered map.
       </li>
       <li>
-        If |ndefRecord|'s <a>PAYLOAD field</a> is not present, set |record|'s mediaType to |mimeType|,
-        set |record|.<a>[[\PayloadData]]</a> to `undefined` and return |record|.
+        If |ndefRecord|'s <a>PAYLOAD field</a> is not present, set
+        |record|.<a>[[\PayloadData]]</a> to `undefined` and return |record|.
       </li>
       <li>
         Let |header:byte| be the first <a>byte</a> of |ndefRecord|'s
@@ -4044,11 +4019,6 @@
       <li>
         Set |record|'s encoding be "`utf-8`" if bit `7` ([=MB field=]) of |header|
         is equal to the value `0`, or else "`utf-16be`".
-      </li>
-      <li>
-        Set |record|'s mediaType to the result of
-        <a>serialize a MIME type</a> with |mimeType| as
-        the input.
       </li>
       <li>
         Let |buffer:byte sequence| be the <a>byte sequence</a> of
@@ -4113,9 +4083,6 @@
         Set |record|'s recordType to "`url`".
       </li>
       <li>
-        Set |record|'s mediaType to "`text/plain`".
-      </li>
-      <li>
         If |ndefRecord|'s <a>PAYLOAD field</a> is not present,
         set |record|.<a>[[\PayloadData]]</a> to `undefined` and return |record|.
       </li>
@@ -4155,9 +4122,6 @@
     <ol class=algorithm>
       <li>
         Set |record|'s recordType to "`smart-poster`".
-      </li>
-      <li>
-        Set |record|'s mediaType to "".
       </li>
       <li>
         If |ndefRecord|'s <a>PAYLOAD field</a> is not present, set |record|.<a>[[\PayloadData]]</a> to `undefined` and return |record|.
@@ -4212,9 +4176,6 @@
           Set |record|'s recordType to "`absolute-url`".
         </li>
         <li>
-          Set |record|'s mediaType to "`text/plain`".
-        </li>
-        <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of
           |ndefRecords|'s <a>TYPE field</a>.
         </li>
@@ -4232,9 +4193,6 @@
       <ol class=algorithm>
         <li>
           Set |record|'s recordType to the value of |ndefRecord|'s <a>TYPE field</a>.
-        </li>
-        <li>
-          Set |record|'s mediaType to "`application/octet-stream`".
         </li>
         <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of
@@ -4257,9 +4215,6 @@
       <ol class=algorithm>
         <li>
           Set |record|'s recordType to "`mime`".
-        </li>
-        <li>
-          Set |record|'s mediaType to "`application/octet-stream`".
         </li>
         <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of

--- a/index.html
+++ b/index.html
@@ -2007,35 +2007,35 @@
       <td>0</td>
       <td><i>unused</i></td>
       <td>"`empty`"</td>
-      <td>`null`</td>
+      <td>`undefined`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`T`"</td>
       <td>"`text`"</td>
-      <td>`null`</td>
+      <td>`undefined`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`U`"</td>
       <td>"`url`"</td>
-      <td>`null`</td>
+      <td>`undefined`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`Sp`"</td>
       <td nowrap>"`smart-poster`"</td>
-      <td>`null`</td>
+      <td>`undefined`</td>
     </tr>
     <tr>
       <td>[=Local type=] record*</td>
       <td>1</td>
       <td>[=local type name=]</td>
       <td>[=local type name=]</td>
-      <td>`null`</td>
+      <td>`undefined`</td>
     </tr>
     <tr>
       <td>[=MIME type record=]</td>
@@ -2049,21 +2049,21 @@
       <td>3</td>
       <td>URL</td>
       <td>"`absolute-url`"</td>
-      <td>`null`</td>
+      <td>`undefined`</td>
     </tr>
     <tr>
       <td>[=External type record=]</a></td>
       <td>4</td>
       <td>[=external type name=]</td>
       <td>[=external type name=]</td>
-      <td>`null`</td>
+      <td>`undefined`</td>
     </tr>
     <tr>
       <td><a>Unknown record</a></td>
       <td>5</td>
       <td><i>unused</i></td>
       <td>"`unknown`"</td>
-      <td>`null`</td>
+      <td>`undefined`</td>
     </tr>
   </table>
   </section>
@@ -3240,6 +3240,16 @@
             If the type of a |record|'s data is not a
             {{BufferSource}}, [= exception/throw =] a {{TypeError}}
             and abort these steps.
+          </li>
+          <li>
+            Let |mimeTypeRecord| be the <a>MIME type</a>
+            returned by running <a>parse a MIME type</a> on |record|'s mediaType.
+            <ol>
+              <li>
+                If |mimeTypeRecord| is failure, let |mimeTypeRecord| be a new
+                <a>MIME type record</a> whose type is "`application`", and subtype is "`octet-stream`".
+              </li>
+            </ol>
           </li>
           <li>
             Set |arrayBuffer| to |record|'s data.


### PR DESCRIPTION
This PR makes `mediaType` optional in NDEFRecord so that it only applies to mime records.

FIX https://github.com/w3c/web-nfc/issues/387


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/415.html" title="Last updated on Oct 28, 2019, 1:08 PM UTC (74dc8d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/415/05d62b5...beaufortfrancois:74dc8d7.html" title="Last updated on Oct 28, 2019, 1:08 PM UTC (74dc8d7)">Diff</a>