### PR TITLE
Throw TypeError if mediaType for non mime records

### DIFF
--- a/index.html
+++ b/index.html
@@ -2995,6 +2995,10 @@
         these steps:
         <ol class=algorithm>
           <li>
+            If |record|'s |mediaType| is not `undefined`, [= exception/throw =]
+            a {{TypeError}} and abort these steps.
+          </li>
+          <li>
             Let |ndef| be the notation for the <a>NDEF record</a> to
             be created by the UA.
           </li>
@@ -3029,6 +3033,10 @@
           "`text/vcard`".
         </p>
         <ol class=algorithm>
+          <li>
+            If |record|'s |mediaType| is not `undefined`, [= exception/throw =]
+            a {{TypeError}} and abort these steps.
+          </li>
           <li>
             If the type of |record|'s data is not a {{DOMString}} or a {{BufferSource}},
             [= exception/throw =] a {{TypeError}} and abort these steps.
@@ -3150,6 +3158,10 @@
         To <dfn>map a URL to NDEF</dfn> given a |record:NDEFRecordInit|, run these
         steps:
         <ol class=algorithm>
+          <li>
+            If |record|'s |mediaType| is not `undefined`, [= exception/throw =]
+            a {{TypeError}} and abort these steps.
+          </li>
           <li>
             If |record|'s data is not a {{DOMString}},
             [= exception/throw =] a {{TypeError}} and abort these steps.
@@ -3293,6 +3305,10 @@
         run these steps:
         <ol class=algorithm>
           <li>
+            If |record|'s |mediaType| is not `undefined`, [= exception/throw =]
+            a {{TypeError}} and abort these steps.
+          </li>
+          <li>
             If the type of a |record|'s data is not a
             {{BufferSource}}, [= exception/throw =] a {{TypeError}}
             and abort these steps.
@@ -3336,6 +3352,10 @@
         To <dfn>map local type to NDEF</dfn> given a |record:NDEFRecordInit|,
         run these steps:
         <ol class=algorithm>
+          <li>
+            If |record|'s |mediaType| is not `undefined`, [= exception/throw =]
+            a {{TypeError}} and abort these steps.
+          </li>
           <li>
             If the type of a |record|'s data is not a
             {{BufferSource}}, [= exception/throw =] a {{TypeError}}


### PR DESCRIPTION
As suggested by https://github.com/w3c/web-nfc/issues/387#issuecomment-543624143, we should throw a TypeError if `mediaType` is not `undefined` for non mime records.

Fix https://github.com/w3c/web-nfc/issues/387


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/419.html" title="Last updated on Oct 28, 2019, 1:30 PM UTC (95cfb30)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/419/e845e7d...beaufortfrancois:95cfb30.html" title="Last updated on Oct 28, 2019, 1:30 PM UTC (95cfb30)">Diff</a>