### PR TITLE
Add unknown record JS example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1415,6 +1415,51 @@
       ]});
     </pre>
   </section>
+
+  <section> <h3>Push and read unknown records inside an external record</h3>
+    <p>
+      Unknown type records may be useful inside external type records as
+      developers know what they represent and therefore can avoid specifying the
+      mime type.
+    </p>
+    <pre class="example">
+      const encoder = new TextEncoder();
+      const writer = new NDEFWriter();
+      writer.push({ records: [
+        {
+          recordType: "example.com:shoppingItem", // External record
+          data: {
+            records: [
+              {
+                recordType: "unknown", // Shopping item name
+                data: encoder.encode("Food")
+              },
+              {
+                recordType: "unknown", // Shopping item description
+                data: encoder.encode("Provide nutritional support for an organism.")
+              }
+            ]
+          }
+        }
+      ]});
+    </pre>
+    <pre class="example">
+      const reader = new NDEFReader();
+      reader.scan({ recordType: "example.com:shoppingItem" });
+      reader.onreading = event => {
+        const shoppingItemRecord = event.message.records[0];
+        if (!shoppingItemRecord) {
+          return;
+        }
+
+        const [nameRecord, descriptionRecord] = shoppingItemRecord.toRecords();
+
+        const decoder = new TextDecoder();
+        console.log("Item name: " + decoder.decode(nameRecord.data));
+        console.log("Item description: " + decoder.decode(descriptionRecord.data));
+      };
+    </pre>
+  </section>
 </section> <!-- Usage examples -->
 
 <!-- - - - - - - - - - - - - Security and Privacy - - - - - - - - - - - - - -->


### PR DESCRIPTION
As suggested by @kenchris, this PR adds a JS example featuring unknown records inside an external record.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/422.html" title="Last updated on Oct 29, 2019, 10:37 AM UTC (dc4fdfe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/422/766310e...beaufortfrancois:dc4fdfe.html" title="Last updated on Oct 29, 2019, 10:37 AM UTC (dc4fdfe)">Diff</a>