### PR TITLE
Add user activation requirement for push and scan

### DIFF
--- a/index.html
+++ b/index.html
@@ -2585,6 +2585,10 @@
             {{DOMException}} and return |p|.
           </li>
           <li>
+            If the algorithm is not <a>triggered by user activation</a>, then
+            reject |p| with a {{"NotAllowedError"}} {{DOMException}} and return |p|.
+          </li>
+          <li>
             Let |signal:AbortSignal| be the |options|’ dictionary member
             of the same name if present, or `null` otherwise.
           </li>
@@ -3637,6 +3641,10 @@
             (e.g. a user preference), then reject |p| with a
             {{"NotReadableError"}} {{DOMException}}
             and return |p|.
+          </li>
+          <li>
+            If the algorithm is not <a>triggered by user activation</a>, then
+            reject |p| with a {{"NotAllowedError"}} {{DOMException}} and return |p|.
           </li>
           <li>
             If |reader|.<a>[[\Signal]]</a>'s [= AbortSignal/aborted flag =] is


### PR DESCRIPTION
@zolkis @kenchris We still need to revamp our security section but I wonder if we should land those changes now.
 
FIX https://github.com/w3c/web-nfc/issues/425


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Nov 4, 2019, 12:53 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fweb-nfc%2F766310e3b9da9f04886a0593a1bbddb7966d6791%2Findex.html%3FisPreview%3Dtrue)

```
[33m📡 HTTP Error 520:[39m [36mhttps://rawcdn.githack.com/w3c/web-nfc/766310e3b9da9f04886a0593a1bbddb7966d6791/index.html[39m
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/web-nfc%23430.)._
</details>
