### PR TITLE
Add onerror NDEFReader event

### DIFF
--- a/index.html
+++ b/index.html
@@ -2137,6 +2137,7 @@
     interface NDEFReader : EventTarget {
       constructor();
 
+      attribute EventHandler onerror;
       attribute EventHandler onreading;
 
       Promise&lt;void&gt; scan(optional NDEFScanOptions options={});
@@ -2272,6 +2273,10 @@
   <p>
     The <dfn data-dfn-for="NDEFReader">onreading</dfn> is an {{EventHandler}} which is called to notify
     that new reading is available.
+  </p>
+  <p>
+    The <dfn data-dfn-for="NDEFReader">onerror</dfn> is an {{EventHandler}}
+    which is called to notify that an error happened when reading.
   </p>
   <section><h3>NFC state associated with the settings object</h3>
   <p>
@@ -3714,12 +3719,21 @@
       </li>
       <li>
         If the <a>NFC device</a> in proximity range does not expose <a>NDEF</a>
-        technology for reading or formatting, abort these steps.
-        <p class="note">
-          This means there is no reading event generated when non-<a>NDEF</a>
-          NFC technology comes in proximity range. This may change in future
-          version of the specification.
-        </p>
+        technology for reading or formatting, run the following sub-steps:
+        <ol>
+          <li>[= list/For each =]
+            {{NDEFReader}} instance |reader:NDEFReader| in the <a>activated reader
+            objects</a>, run the following sub-steps:
+            <ol>
+              <li>
+                <a>Fire an event</a> named "`error`" at |reader|.
+              </li>
+            </ol>
+          </li>
+          <li>
+            Abort these steps.
+          </li>
+        </ol>
       </li>
       <li>
         Let |serialNumber:serialNumber| be the device identifier as a series of

--- a/index.html
+++ b/index.html
@@ -2276,7 +2276,7 @@
   </p>
   <p>
     The <dfn data-dfn-for="NDEFReader">onerror</dfn> is an {{EventHandler}}
-    which is called to notify that an error happened when reading.
+    which is called to notify that an error happened during reading.
   </p>
   <section><h3>NFC state associated with the settings object</h3>
   <p>


### PR DESCRIPTION
This PR adds back the `onerror` NDEFReader event. It is only fired when the NFC device in proximity range does not expose NDEF technology for reading or formatting when `scan()` has started.

FIX: https://github.com/w3c/web-nfc/issues/279


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/432.html" title="Last updated on Nov 5, 2019, 7:52 AM UTC (fa84e47)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/432/4d4e377...beaufortfrancois:fa84e47.html" title="Last updated on Nov 5, 2019, 7:52 AM UTC (fa84e47)">Diff</a>