### PR TITLE
Fix "Parsing NDEF absolute-URL records" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4177,6 +4177,9 @@
           |ndefRecords|'s <a>TYPE field</a>.
         </li>
         <li>
+          Set |record|.<a>[[\PayloadData]]</a> to |buffer|.
+        </li>
+        <li>
           return |record|.
         </li>
       </ol>  <!-- parsing NDEF absolute URI record -->


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/pull/433.html" title="Last updated on Nov 5, 2019, 9:32 AM UTC (eb30a9e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/433/4d4e377...eb30a9e.html" title="Last updated on Nov 5, 2019, 9:32 AM UTC (eb30a9e)">Diff</a>