### PR TITLE
Add onerror example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1131,6 +1131,28 @@
     </pre>
   </section>
 
+
+  <section> <h3>Handle scanning errors</h3>
+    <p>
+      This example shows what happens when [=NDEFReader/scan=] promise rejects and
+      [=NDEFReader/onerror=] is fired.
+    </p>
+    <pre class="example">
+      const reader = new NDEFReader();
+      reader.scan().then(() => {
+        console.log("Scan started successfully.");
+        reader.onerror = event => {
+          console.log("Error! Cannot read data from NFC tag.");
+        };
+        reader.onreading = event => {
+          console.log("NDEF message read.");
+        };
+      }).catch(error => {
+        console.log(`Scan failed to start :-( try again: ${error}.`);
+      });
+    </pre>
+  </section>
+
   <section> <h3>Read data from tag, and write to empty ones</h3>
     <p>
       This example shows reading various different kinds of data which can be

--- a/index.html
+++ b/index.html
@@ -1142,13 +1142,13 @@
       reader.scan().then(() => {
         console.log("Scan started successfully.");
         reader.onerror = event => {
-          console.log("Error! Cannot read data from NFC tag.");
+          console.log("Error! Cannot read data from the NFC tag. Try a different one?");
         };
         reader.onreading = event => {
           console.log("NDEF message read.");
         };
       }).catch(error => {
-        console.log(`Scan failed to start :-( try again: ${error}.`);
+        console.log(`Error! Scan failed to start: ${error}.`);
       });
     </pre>
   </section>


### PR DESCRIPTION
This PR addresses comment posted by @reillyeon in https://github.com/w3c/web-nfc/pull/432#issuecomment-550478360


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/439.html" title="Last updated on Nov 18, 2019, 1:51 PM UTC (c5109bc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/439/6b0cdb8...beaufortfrancois:c5109bc.html" title="Last updated on Nov 18, 2019, 1:51 PM UTC (c5109bc)">Diff</a>