### PR TITLE
Update Security section

### DIFF
--- a/index.html
+++ b/index.html
@@ -4293,7 +4293,8 @@
             <li>
               For trusting the integrity of the data exchanged via NFC, user
               agents MAY use encrypted <a>NFC content</a> with key management
-              based on Public Key Infrastructure. Key management is out of the scope of Web NFC.
+              based on Public Key Infrastructure.
+              Key management is out of the scope of Web NFC.
               <p class="note">
                 This is different from application level end to end encryption.
                 Key management is then in application domain.
@@ -4328,30 +4329,29 @@
 
     <section> <h3>Content identification</h3>
       <p>
-        Implementations or applications MAY use an identification mechanism for telling apart “Web NFC content" from generic NFC content. Also, a
-        mechanism for conveying implementation specific metadata which is not exposed to applications MAY be implemented.
+        Implementations or applications MAY use an identification mechanism for
+        telling apart “Web NFC content" from generic NFC content. Also, a
+        mechanism for conveying implementation specific metadata which is not
+        exposed to applications MAY be implemented.
       </p>
+      <section> <h4>Store site URL as record identifier when writing data</h4>
+        <p>
+          When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
+          <a data-cite="dom#concept-host-serializer">serialized</a>,
+          of the <a>current settings object</a> MAY be stored as the <a>record
+          identifier</a> in each top-level <a>NDEF Record</a>.
+          This does not make the payload trusted.
+        </p>
+      </section>
+      <section> <h4>Include URI records with registrable domain</h4>
+        <p>
+          When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
+          <a data-cite="dom#concept-host-serializer">serialized</a>,
+          of the <a>current settings object</a> MAY be stored as a signed
+          <a>URI record</a>. This does not make other records trusted.
+        </p>
+      </section>
     </section>
-
-    <!--
-    <section> <h3>Store site URL as record identifier when writing data</h3>
-      <p>
-        When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
-        <a data-cite="dom#concept-host-serializer">serialized</a>,
-        of the <a>current settings object</a> MAY be stored as the <a>record
-        identifier</a> in each top-level <a>NDEF Record</a>. This does not make
-        the payload trusted.
-      </p>
-    </section>
-    <section> <h3>Include URI records with registrable domain</h3>
-      <p>
-        When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
-        <a data-cite="dom#concept-host-serializer">serialized</a>,
-        of the <a>current settings object</a> MAY be stored as a signed
-        <a>URI record</a>. This does not make other records trusted.
-      </p>
-    </section>
-    -->
   </section>
 
   <section> <h3>Security policies</h3>
@@ -4439,24 +4439,35 @@
         allowing surface to attacks. Version 2.0 of [[NFC-SECURITY]] included
         tag hardware attributes in the signature and allowed for shorter
         certificates.
-        Therefore the following additional policies apply:
+        In this version of the specification the following policies are
+        recommended:
         <ul>
           <li>
-            A <a>smart poster</a> can be trusted only if signed by using
+            A <a>smart poster</a> MAY be trusted only if signed by using
             a single <a>NDEF signature</a> record by the same issuer.
           </li>
           <li>
-            An <a>NDEF message</a> can be trusted only if signed by
+            An <a>NDEF message</a> MAY be trusted only if signed by
             a single <a>NDEF signature</a> record by the same issuer.
+          </li>
+          <li>
+            User agents expose <a>NDEF signature</a> records without verifying
+            them. It is applications' responsibility to verify signatures and
+            to sign <a>NFC content</a>.
+            <p class="note">
+              Indication whether <a>NFC content</a> is trusted may be added in
+              future versions. Also, origin policies MAY be applied in order to
+              relax user prompting when a trust chain could be established.
+            </p>
           </li>
         </ul>
       </div>
     </section>
-      <!--p>
-        For Bluetooth and WiFi handover (supported in later versions),
-        the user should have to grant access to the secondary API and must be
-        able to properly understand what they are granting.
-      </p-->
+    <p class="note">
+      For Bluetooth and WiFi handover (supported in later versions),
+      the user should have to grant access to the secondary API and must be
+      able to properly understand what they are granting.
+    </p>
   </section> <!-- Policies -->
 </section> <!-- Security and Privacy  -->
 

--- a/index.html
+++ b/index.html
@@ -2612,10 +2612,6 @@
         To <dfn>obtain push permission</dfn>, run these steps:
         <ol class=algorithm>
           <li>
-            If there is a <a>prearranged trust relationship</a>,
-            return `true`.
-          </li>
-          <li>
             Run the
             <a>query a permission</a> steps for the
             <a>Web NFC permission name</a> until completion.
@@ -3502,10 +3498,6 @@
         To <dfn>obtain reading permission</dfn>, run these steps:
         <ol>
           <li>
-            If there is a <a>prearranged trust relationship</a>,
-            return `true`.
-          </li>
-          <li>
             Otherwise, if the user has earlier denied permission for the calling
             <a>origin</a> for all future calls of
             <a data-link-for="NDEFReader">scan()</a>
@@ -4095,9 +4087,9 @@
       specification.
     </p>
     <p>
-      The integrity of <a>NFC content</a> SHOULD NOT be trusted by web sites
-      and applications unless it is encrypted by applications, or a
-      <a>prearranged trust relationship</a> exists.
+      The integrity of <a>NFC content</a> MAY be trusted by web sites
+      and applications only if encrypted by applications, or if signed
+      with an <a>NDEF signature</a>.
     </p>
     <p>
       Security considerations for media types in general are discussed in
@@ -4229,18 +4221,15 @@
       In order to support security policies concerning Web NFC, the following
       mechanisms are recommended for the implementations.
     </p>
-    <section> <h3><dfn>Obtain permission</dfn></h3>
-      Implementations SHOULD use one or more of the following mechanisms for
-      <dfn>obtaining permission</dfn>.
+    <section> <h3><dfn>Obtaining permission</dfn></h3>
+      Implementations SHOULD use one or more of the following mechanisms to
+      <dfn>obtain permission</dfn>.
       <ul>
         <li>
           A mechanism for obtaining <a>expressed permission</a> of the user.
         </li>
         <li>
           A mechanism for <a>ask for forgiveness</a> policies.
-        </li>
-        <li>
-          A mechanism for <a>prearranged trust relationship</a>.
         </li>
       </ul>
       <section> <h4><dfn>Expressed permission</dfn></h4>
@@ -4265,47 +4254,22 @@
           handle future occurences of the same operation by the same action.
         </p>
       </section>
-      <section> <h4><dfn>Prearranged trust relationship</dfn></h4>
-        <div>
-          A prearranged trust relationship means the UA has already
-          established a trust relationship for a certain operation using a
-          platform specific mechanism, so that an <a>expressed permission</a>
-          from the user is not any more needed. A few examples are given below.
-          <ul>
-            <li>
-              Web apps installed from a store, or web pages installed to home
-              screen (with [[appmanifest]]) MAY be considered trusted by the user
-              agent. In this case the trust concerns the web page and allowed
-              NFC functionality, but does not necessarily also concern the
-              data exchanged through NFC.
-            </li>
-            <li>
-              For trusting the integrity of the data exchanged via NFC, user
-              agents MAY use encrypted <a>NFC content</a> with key management
-              based on Public Key Infrastructure.
-              Key management is out of the scope of Web NFC.
-              <p class="note">
-                This is different from application level end to end encryption.
-                Key management is then in application domain.
-              </p>
-            </li>
-            <li>
-              User agents MAY consider using <a>NDEF signature</a> records for
-              <a>NFC content</a> integrity. When <a>NDEF record</a>s are signed
-              with a site certificate, then that is considered
-              <a>prearranged trust relationship</a> and browser origin policy
-              MAY be applied to relax the security policies in this document,
-              in the case when the user agent wants to minimize or eliminate
-              user prompts involved in obtaining permissions.
-              The signing tools and Public Key Infrastructure for key management
-              are out of scope of Web NFC.
-            </li>
-          </ul>
-        </div>
-      </section>
     </section>
 
-    <section> <h3>Sign NDEF records</h3>
+    <section> <h3>Encrypting <a>NFC content</a></h3>
+      <p>
+        For trusting the integrity of the data exchanged via NFC, user agents
+        MAY use encrypted <a>NFC content</a> with key management based on
+        Public Key Infrastructure (PKI).
+        Key management is out of the scope of Web NFC.
+      </p>
+      <p class="note">
+        This is different from application level end to end encryption.
+        Key management is then in application domain.
+      </p>
+    </section>
+
+    <section> <h3>Signing NDEF records</h3>
       <p>
         When pushing an <a>NDEF message</a>, one, more, or all records MAY be
         signed using an <a>NDEF signature</a>.
@@ -4313,6 +4277,14 @@
       <p>
         In order to build a trust chain, a Public Key Infrastructure is also
         needed for key management.
+      </p>
+      <p>
+        For tags signed with <a>NDEF signature</a> version 1.0 ([[NFC-SECURITY]]),
+        the signature is applied only to the <a>TYPE field</a>, <a>ID field</a>
+        and <a>PAYLOAD field</a>, leaving out the first byte of the NDEF header,
+        allowing surface to attacks. Version 2.0 of [[NFC-SECURITY]] included
+        tag hardware attributes in the signature and allowed for shorter
+        certificates.
       </p>
     </section>
 
@@ -4403,7 +4375,7 @@
       -->
     </section>
 
-    <section> <h4>Warn risk of physical location leak</h4>
+    <section> <h4>Warn about risk of physical location leak</h4>
       <p>
         When listening for and pushing <a>NFC content</a>,
         the UA MAY warn the user that the given <a>origin</a> may be able to
@@ -4422,12 +4394,6 @@
 
     <section> <h4>Signing <a>NFC content</a></h4>
       <div>
-        For tags signed with <a>NDEF signature</a> version 1.0 ([[NFC-SECURITY]]),
-        the signature is applied only to the <a>TYPE field</a>, <a>ID field</a>
-        and <a>PAYLOAD field</a>, leaving out the first byte of the NDEF header,
-        allowing surface to attacks. Version 2.0 of [[NFC-SECURITY]] included
-        tag hardware attributes in the signature and allowed for shorter
-        certificates.
         In this version of the specification the following policies are
         recommended:
         <ul>

--- a/index.html
+++ b/index.html
@@ -235,12 +235,12 @@
   <div>
     An <dfn>NFC tag</dfn> is a passive NFC device.
     The <a>NFC tag</a> is powered by magnetic induction when an active NFC
-    device is in proximity range. An <a>NFC tag</a> contains a single
-    <a>NDEF message</a>.
+    device is in proximity range. An <a>NFC tag</a> that supports <a>NDEF</a>
+    contains a single <a>NDEF message</a>.
     <p class="note">
       The way of reading the message may happen through proprietary
       technologies, which require the reader and the tag to be of the same
-      manufacturer. Implementations are expected to encapsulate this.
+      manufacturer. They may also expose an <a>NDEF</a> message.
     </p>
   </div>
   <p>
@@ -4079,19 +4079,46 @@
       specification.
     </p>
     <p>
-      The integrity of <a>NFC content</a> MAY be trusted by web sites
-      and applications only if encrypted by applications, or if signed
-      with an <a>NDEF signature</a>.
+      For trusting the <strong>confidentiality</strong> of the data exchanged
+      via NFC, user agents MAY use encrypted <a>NFC content</a>.
     </p>
     <p>
-      For trusting the integrity of the data exchanged via NFC, user agents MAY
-      use encrypted <a>NFC content</a> or an <a>NDEF signature</a>, with key
-      management based on Public Key Infrastructure (PKI).
+      For trusting the <strong>integrity</strong> of the data exchanged via NFC,
+      user agents MAY use an <a>NDEF signature</a>, with key management based on
+      Public Key Infrastructure (PKI).
     </p>
     <p>
       Security considerations for media types in general are discussed in
       [[RFC2048]] and [[RFC2046]].
     </p>
+  </section>
+
+  <section class="informative"> <h2>Assets</h2>
+    <div>
+      Assets to be protected include the following:
+      <ul>
+        <li>
+          <strong>NFC tag and content</strong>, against data damages caused via
+          Web NFC. This includes Denial of Service attacks against a solution
+          deployed with NFC tags (e.g. a malicious actor destroying tags linked
+          to a solution).
+        </li>
+        <li>
+          <strong>User location</strong> that can be indirectly determined by
+          using NFC by tag content creator, used directly or leaking forward to
+          third parties.
+        </li>
+        <li>
+          <strong>User identity</strong> interacting with a site using Web NFC.
+        </li>
+        <li>
+          <strong>User data</strong> exposed to a web page using Web NFC.
+        </li>
+        <li>
+          <strong>User device</strong> running a web page using Web NFC.
+        </li>
+      </ul>
+    </div>
   </section>
 
   <section class="informative"> <h2>Attacker model</h2>
@@ -4108,10 +4135,14 @@
           phishing user location, causing side actions such as installing
           applications, trigger automated dispatching or other actions.
         </li>
+        <li>
+          malicious user: destroying tags, harming integrity, creating malicious tag and web page.
+        </li>
       </ul>
     </p>
   </section>
 
+<!-- TODO: this section is being rewritten and to be removed later
   <section class="informative"> <h3>Threats</h3>
     <p>
       Potential threats for Web NFC are given below.
@@ -4177,7 +4208,9 @@
           Support for smart posters is not among the main use cases of Web
           NFC; if and when supported, no automatic actions should be allowed,
           the user must be made aware and given the ability to control what is
-          happening during the NFC communication.
+          happening during the NFC communication. For instance: opening content
+          from <a>smart poster</a>, automatic connection to (possibly malicious)
+          WiFi via <a>NFC handover</a>, etc.
         </td>
       </tr>
       <tr>
@@ -4211,6 +4244,167 @@
         </td>
       </tr>
     </table>
+  </section>
+TODO delete -->
+
+  <section class="informative"> <h3>Threats</h3>
+    <p>
+      Potential threats for Web NFC are given below.
+    </p>
+
+    <section> <h4>Fingerprinting and data collection</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          Web page using Web NFC collects user data without user consent and
+          writes it to publicly accessible tags.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          User data, user identity.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious web page using Web NFC.
+        </dd>
+        <dt><strong>Stakeholders</strong></dt>
+        <dd>
+          Web NFC implementation, browser.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          The user SHOULD be able to be aware of what data can be shared using
+          NFC from the given web page.
+          Use permissions and user prompts for accessing personal data,
+          minimize user data exposed to NFC.
+        </dd>
+      </dl>
+    </section>
+
+    <section> <h4>Overwriting tags</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          Malicious web page overwrites tags without user consent.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          NFC tags, NFC content.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious web page.
+        </dd>
+        <dt><strong>Stakeholders</strong></dt>
+        <dd>
+          Browser, Web NFC implementation.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          Require permission and user prompt needed for writing tags.
+          Or, control what tags can be written by a given web page, for instance
+          a web page can write only a tag which can be connected to its origin.
+          Or, allow overwriting since tags not meant to be written can be
+          protected by making them read only.
+        </dd>
+      </dl>
+    </section>
+
+    <section> <h4>Tag used for attacking user device</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          Malicious tag may be involuntarily or voluntarily read by devices
+          and the data read may constitute an attack vector on the user agent.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          User device, user data, user identity.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious tag.
+        </dd>
+        <dt><strong>Stakeholders</strong></dt>
+        <dd>
+          Browser, Web NFC implementation.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          This is a generic problem with all existing NFC tags.
+          The data is considered application specific.
+          Implementations need security hardening.
+          Involuntary touch is low probability due to short range and critical
+          angle for reading, and due to the focus requirements.
+        </dd>
+      </dl>
+    </section>
+
+    <section> <h4>Tag triggering malicious action</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          Malicious smart poster or other tag attempts triggering an action on
+          the device which may be a threat, for instance launching a malicious
+          web site, or opening an image prepared for attacking the device.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          User device, user data.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious tag.
+        </dd>
+        <dt><strong>Stakeholders</strong></dt>
+        <dd>
+          Web NFC implementation. Browser.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          Automatic actions for smart posters and other tags should not be
+          allowed. The user must be made aware and given the ability to control
+          what is happening during the NFC communication. For instance, opening
+          content from <a>smart poster</a>, automatic connection to (possibly
+          malicious) WiFi via <a>NFC handover</a>, etc.
+        </dd>
+      </dl>
+    </section>
+
+    <section> <h4>Leaking user location</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          A Web NFC tag could be used for leaking the user’s physical location,
+          if the reading triggers a user’s device to navigate to a website
+          that can identify the tag and knows the tag's physical location.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          User location.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious web site, malicious tag.
+        </dd>
+        <dt><strong>Stakeholders</strong></dt>
+        <dd>
+          Browser, Web NFC implementation.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          A NFC tag SHOULD NOT ever trigger a user’s device to navigate
+          to a website without asking permission, unless the site has been in
+          the foreground or has been brought to the foreground and has been
+          granted permission. User agents SHOULD take into account the
+          security and privacy measures listed in the
+          <a href="http://dev.w3.org/geo/api/spec-source.html#security">
+          Geolocation API</a>.
+        </dd>
+      </dl>
+    </section>
+
+
   </section>
 
   <section class="informative"> <h2>Security mechanisms</h2>
@@ -4255,7 +4449,7 @@
 
     <section> <h3>Encrypting <a>NFC content</a></h3>
       <p>
-        For trusting the integrity of the data exchanged via NFC, user agents
+        For trusting the confidentiality of the data exchanged via NFC, user agents
         MAY use encrypted <a>NFC content</a> with key management based on
         Public Key Infrastructure (PKI).
         Key management is out of the scope of Web NFC.
@@ -4268,12 +4462,9 @@
 
     <section> <h3>Signing NDEF records</h3>
       <p>
-        When pushing an <a>NDEF message</a>, one, more, or all records MAY be
-        signed using an <a>NDEF signature</a>.
-      </p>
-      <p>
-        In order to build a trust chain, a Public Key Infrastructure is also
-        needed for key management.
+        For trusting the integrity of the data exchanged via NFC, user agents
+        MAY use an <a>NDEF signature</a> with a Public Key Infrastructure
+        for key management.
       </p>
       <p>
         For tags signed with <a>NDEF signature</a> version 1.0 ([[NFC-SECURITY]]),

--- a/index.html
+++ b/index.html
@@ -4092,30 +4092,36 @@
       [[RFC2048]] and [[RFC2046]].
     </p>
   </section>
-
+  
   <section class="informative"> <h2>Assets</h2>
     <div>
       Assets to be protected include the following:
       <ul>
         <li>
-          <strong>NFC tag and content</strong>, against data damages caused via
-          Web NFC. This includes Denial of Service attacks against a solution
+          <strong>NDEF message records, including payload and associated metadata
+          </strong> in-transfer and in-storage (when tag is being overwritten via
+          Web NFC triggered action), against data disclosure or data modification.
+          This also includes Denial of Service attacks against a solution
           deployed with NFC tags (e.g. a malicious actor destroying tags linked
           to a solution).
         </li>
         <li>
-          <strong>User location</strong> that can be indirectly determined by
-          using NFC by tag content creator, used directly or leaking forward to
-          third parties.
-        </li>
-        <li>
-          <strong>User identity</strong> interacting with a site using Web NFC.
+          <strong>User identity or other privacy sensitive attributes</strong>
+          that can be directly or indirectly determined by using NFC by tag
+          content creator or exposed to a web page using Web NFC. They can be
+          used directly or leaking forward to third parties. Examples are user
+          location, user device identifier and user identifier.
         </li>
         <li>
           <strong>User data</strong> exposed to a web page using Web NFC.
+          While web page might collect user data using other means than 
+          web NFC protocol, it might embed this data into NDFE records 
+          shared via web NFC protocol. 
         </li>
         <li>
-          <strong>User device</strong> running a web page using Web NFC.
+          <strong>Integrity of user device</strong>.
+          A read of an NFC tag might result in a user device compromise
+          that can further lead to loss of other web NFC or platform assets. 
         </li>
       </ul>
     </div>
@@ -4126,21 +4132,27 @@
       The following attacker patterns have been considered:
       <ul>
         <li>
-          malicious web page: phishing user data or location, destroying tags,
-          modifying an NFC tag to cause indirect damage through fake identities
-          and attack vectors;
+          Malicious web page creator: phishing user data, identity or 
+          other privacy sensitive attributes, destroying or modifying NFC tags to 
+          cause further damage through fake identities and attack vectors;
         </li>
         <li>
-          malicious tag: data injection, redirect to malicious web page,
-          phishing user location, causing side actions such as installing
-          applications, trigger automated dispatching or other actions.
+          Malicious NFC tag creator: same as malicious web page owner, but
+          it has a possibility to create, delete or modify the NFC tags locally. 
+          As a result can compromise integrity of user device, cause data
+          injection, redirect to malicious web page, phishing user location, 
+          causing side actions such as installing applications, trigger automated
+          dispatching or other actions.
         </li>
         <li>
-          malicious user: destroying tags, harming integrity, creating malicious tag and web page.
+          Malicious MitM user: any MitM-style attack between a legitimate Web NFC frontend
+          and a user device using Web NFC interfaces. Also includes attempts to interact
+          with a legitimate web page exposing Web NFC frontend by presenting modified or
+          replayed NDFE records.
         </li>
       </ul>
     </p>
-  </section>
+  </section> 
 
 <!-- TODO: this section is being rewritten and to be removed later
   <section class="informative"> <h3>Threats</h3>
@@ -4247,7 +4259,7 @@
   </section>
 TODO delete -->
 
-  <section class="informative"> <h3>Threats</h3>
+ <section class="informative"> <h3>Threats</h3>
     <p>
       Potential threats for Web NFC are given below.
     </p>
@@ -4256,20 +4268,18 @@ TODO delete -->
       <dl>
         <dt><strong>Threat description</strong></dt>
         <dd>
-          Web page using Web NFC collects user data without user consent and
-          writes it to publicly accessible tags.
+          Malicious web page collects user data, identity or other privacy
+          sensitive attributes (such as location) without user consent and
+          exposes it to third parties (writing it to NFC tags, sending to other
+          web NFC providers, etc.)
         </dd>
         <dt><strong>Affected assets</strong></dt>
         <dd>
-          User data, user identity.
+          User data, user identity or other privacy sensitive attributes
         </dd>
         <dt><strong>Actors</strong></dt>
         <dd>
-          Malicious web page using Web NFC.
-        </dd>
-        <dt><strong>Stakeholders</strong></dt>
-        <dd>
-          Web NFC implementation, browser.
+          Malicious web page owner using Web NFC, malicious tag owner. 
         </dd>
         <dt><strong>Mitigation, comments</strong></dt>
         <dd>
@@ -4277,122 +4287,6 @@ TODO delete -->
           NFC from the given web page.
           Use permissions and user prompts for accessing personal data,
           minimize user data exposed to NFC.
-        </dd>
-      </dl>
-    </section>
-
-    <section> <h4>Overwriting tags</h4>
-      <dl>
-        <dt><strong>Threat description</strong></dt>
-        <dd>
-          Malicious web page overwrites tags without user consent.
-        </dd>
-        <dt><strong>Affected assets</strong></dt>
-        <dd>
-          NFC tags, NFC content.
-        </dd>
-        <dt><strong>Actors</strong></dt>
-        <dd>
-          Malicious web page.
-        </dd>
-        <dt><strong>Stakeholders</strong></dt>
-        <dd>
-          Browser, Web NFC implementation.
-        </dd>
-        <dt><strong>Mitigation, comments</strong></dt>
-        <dd>
-          Require permission and user prompt needed for writing tags.
-          Or, control what tags can be written by a given web page, for instance
-          a web page can write only a tag which can be connected to its origin.
-          Or, allow overwriting since tags not meant to be written can be
-          protected by making them read only.
-        </dd>
-      </dl>
-    </section>
-
-    <section> <h4>Tag used for attacking user device</h4>
-      <dl>
-        <dt><strong>Threat description</strong></dt>
-        <dd>
-          Malicious tag may be involuntarily or voluntarily read by devices
-          and the data read may constitute an attack vector on the user agent.
-        </dd>
-        <dt><strong>Affected assets</strong></dt>
-        <dd>
-          User device, user data, user identity.
-        </dd>
-        <dt><strong>Actors</strong></dt>
-        <dd>
-          Malicious tag.
-        </dd>
-        <dt><strong>Stakeholders</strong></dt>
-        <dd>
-          Browser, Web NFC implementation.
-        </dd>
-        <dt><strong>Mitigation, comments</strong></dt>
-        <dd>
-          This is a generic problem with all existing NFC tags.
-          The data is considered application specific.
-          Implementations need security hardening.
-          Involuntary touch is low probability due to short range and critical
-          angle for reading, and due to the focus requirements.
-        </dd>
-      </dl>
-    </section>
-
-    <section> <h4>Tag triggering malicious action</h4>
-      <dl>
-        <dt><strong>Threat description</strong></dt>
-        <dd>
-          Malicious smart poster or other tag attempts triggering an action on
-          the device which may be a threat, for instance launching a malicious
-          web site, or opening an image prepared for attacking the device.
-        </dd>
-        <dt><strong>Affected assets</strong></dt>
-        <dd>
-          User device, user data.
-        </dd>
-        <dt><strong>Actors</strong></dt>
-        <dd>
-          Malicious tag.
-        </dd>
-        <dt><strong>Stakeholders</strong></dt>
-        <dd>
-          Web NFC implementation. Browser.
-        </dd>
-        <dt><strong>Mitigation, comments</strong></dt>
-        <dd>
-          Automatic actions for smart posters and other tags should not be
-          allowed. The user must be made aware and given the ability to control
-          what is happening during the NFC communication. For instance, opening
-          content from <a>smart poster</a>, automatic connection to (possibly
-          malicious) WiFi via <a>NFC handover</a>, etc.
-        </dd>
-      </dl>
-    </section>
-
-    <section> <h4>Leaking user location</h4>
-      <dl>
-        <dt><strong>Threat description</strong></dt>
-        <dd>
-          A Web NFC tag could be used for leaking the user’s physical location,
-          if the reading triggers a user’s device to navigate to a website
-          that can identify the tag and knows the tag's physical location.
-        </dd>
-        <dt><strong>Affected assets</strong></dt>
-        <dd>
-          User location.
-        </dd>
-        <dt><strong>Actors</strong></dt>
-        <dd>
-          Malicious web site, malicious tag.
-        </dd>
-        <dt><strong>Stakeholders</strong></dt>
-        <dd>
-          Browser, Web NFC implementation.
-        </dd>
-        <dt><strong>Mitigation, comments</strong></dt>
-        <dd>
           A NFC tag SHOULD NOT ever trigger a user’s device to navigate
           to a website without asking permission, unless the site has been in
           the foreground or has been brought to the foreground and has been
@@ -4404,8 +4298,126 @@ TODO delete -->
       </dl>
     </section>
 
+    <section> <h4>NFC tag modification</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          An NFC tag is being modified without user consent.
+          This might enable further attacks using a malicious tag
+          or can be a Denial of Service attack to make a tag
+          unusable by other users. 
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          NDEF message records, including payload and associated metadata
+          in-storage.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious web page creator, malicious MitM user.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          Require permission and user prompt needed for writing tags.
+          Or, control what tags can be written by a given web page, for instance
+          a web page can write only a tag which can be connected to its origin.
+          Or, allow overwriting since tags not meant to be written can be
+          protected by making them read only.
+          Use NDFE signature to detect a modification of NFC tags. 
+        </dd>
+      </dl>
+    </section>
 
+    <section> <h4>Active attack via malicious NFC tag</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          Malicious tag may be involuntarily or voluntarily read by devices
+          and the data read may constitute an attack vector on the user agent.
+          For example it can attempt to trigger an action on
+          the device which may be a threat, for instance launching a malicious
+          web site, or opening an image prepared for attacking the device.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          Integrity of user device, all other web NFC assets.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious tag creator.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          This is a generic problem with all existing NFC tags.
+          The data is considered application specific.
+          Implementations need security hardening.
+          Involuntary touch is low probability due to short range and critical
+          angle for reading, and due to the focus requirements.
+          Automatic actions for smart posters and other tags should not be
+          allowed. The user must be made aware and given the ability to control
+          what is happening during the NFC communication. For instance, opening
+          content from <a>smart poster</a>, automatic connection to (possibly
+          malicious) WiFi via <a>NFC handover</a>, etc.
+          Do no allow actions from untrusted NFC tags, trust can be established
+          via the NDFE signature check. 
+        </dd>
+      </dl>
+    </section>
+
+    <section> <h4>NDFE record modification in-transit</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          NDFE records transferred between the web NFC frontend/backend and 
+          user device are modified to cause various MitM attacks or
+          Denial of Service.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          NDEF message records, including payload and associated metadata
+          in-transfer.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious MitM user.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          Use NDFE signatures to protect the NFC tag payload
+          and metadata. Additionally, harden the platform stack and 
+          communication between the web NFC frontend and backend. 
+        </dd>
+      </dl>
+    </section>
+    
+    <section> <h4>NDFE record payload disclosure</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          Confidential payload of NDFE records in-storage (stored 
+          on a NFC tag) or in-transfer between the web NFC
+          frontend/backend and user device
+          are read by unauthorized parties. 
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          Confidential NDEF message payload 
+          in-transfer and in-storage.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious MitM user, malicious web page creator.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          Use encryption for the payload and secure communication
+          protocols for data exchange, authentication and authorization
+          mechanisms between the web NFC page and NFC tag.
+        </dd>
+      </dl>
+    </section>    
   </section>
+
 
   <section class="informative"> <h2>Security mechanisms</h2>
     <p>

--- a/index.html
+++ b/index.html
@@ -4092,7 +4092,7 @@
       [[RFC2048]] and [[RFC2046]].
     </p>
   </section>
-  
+
   <section class="informative"> <h2>Assets</h2>
     <div>
       Assets to be protected include the following:
@@ -4114,14 +4114,14 @@
         </li>
         <li>
           <strong>User data</strong> exposed to a web page using Web NFC.
-          While web page might collect user data using other means than 
-          web NFC protocol, it might embed this data into NDFE records 
-          shared via web NFC protocol. 
+          While web page might collect user data using other means than
+          web NFC protocol, it might embed this data into NDEF records
+          shared via Web NFC.
         </li>
         <li>
           <strong>Integrity of user device</strong>.
           A read of an NFC tag might result in a user device compromise
-          that can further lead to loss of other web NFC or platform assets. 
+          that can further lead to loss of other web NFC or platform assets.
         </li>
       </ul>
     </div>
@@ -4132,27 +4132,27 @@
       The following attacker patterns have been considered:
       <ul>
         <li>
-          Malicious web page creator: phishing user data, identity or 
-          other privacy sensitive attributes, destroying or modifying NFC tags to 
+          Malicious web page creator: phishing user data, identity or
+          other privacy sensitive attributes, destroying or modifying NFC tags to
           cause further damage through fake identities and attack vectors;
         </li>
         <li>
           Malicious NFC tag creator: same as malicious web page owner, but
-          it has a possibility to create, delete or modify the NFC tags locally. 
+          it has a possibility to create, delete or modify the NFC tags locally.
           As a result can compromise integrity of user device, cause data
-          injection, redirect to malicious web page, phishing user location, 
+          injection, redirect to malicious web page, phishing user location,
           causing side actions such as installing applications, trigger automated
           dispatching or other actions.
         </li>
         <li>
-          Malicious MitM user: any MitM-style attack between a legitimate Web NFC frontend
-          and a user device using Web NFC interfaces. Also includes attempts to interact
-          with a legitimate web page exposing Web NFC frontend by presenting modified or
-          replayed NDFE records.
+          Malicious MitM user: any MitM-style attack between a legitimate Web
+          NFC frontend and a user device using Web NFC interfaces. Also includes
+          attempts to interact with a legitimate web page exposing Web NFC
+          frontend by presenting modified or replayed NDEF records.
         </li>
       </ul>
     </p>
-  </section> 
+  </section>
 
 <!-- TODO: this section is being rewritten and to be removed later
   <section class="informative"> <h3>Threats</h3>
@@ -4279,7 +4279,7 @@ TODO delete -->
         </dd>
         <dt><strong>Actors</strong></dt>
         <dd>
-          Malicious web page owner using Web NFC, malicious tag owner. 
+          Malicious web page owner using Web NFC, malicious tag owner.
         </dd>
         <dt><strong>Mitigation, comments</strong></dt>
         <dd>
@@ -4305,12 +4305,11 @@ TODO delete -->
           An NFC tag is being modified without user consent.
           This might enable further attacks using a malicious tag
           or can be a Denial of Service attack to make a tag
-          unusable by other users. 
+          unusable by other users.
         </dd>
         <dt><strong>Affected assets</strong></dt>
         <dd>
-          NDEF message records, including payload and associated metadata
-          in-storage.
+          NDEF message records, including payload and header in-storage.
         </dd>
         <dt><strong>Actors</strong></dt>
         <dd>
@@ -4323,7 +4322,7 @@ TODO delete -->
           a web page can write only a tag which can be connected to its origin.
           Or, allow overwriting since tags not meant to be written can be
           protected by making them read only.
-          Use NDFE signature to detect a modification of NFC tags. 
+          Use <a>NDEF signature</a> to detect a modification of NFC tags.
         </dd>
       </dl>
     </section>
@@ -4359,17 +4358,17 @@ TODO delete -->
           content from <a>smart poster</a>, automatic connection to (possibly
           malicious) WiFi via <a>NFC handover</a>, etc.
           Do no allow actions from untrusted NFC tags, trust can be established
-          via the NDFE signature check. 
+          via the <a>NDEF signature</a> check.
         </dd>
       </dl>
     </section>
 
-    <section> <h4>NDFE record modification in-transit</h4>
+    <section> <h4>NDEF record modification in-transit</h4>
       <dl>
         <dt><strong>Threat description</strong></dt>
         <dd>
-          NDFE records transferred between the web NFC frontend/backend and 
-          user device are modified to cause various MitM attacks or
+          <a>NDEF record</a>s transferred between the web NFC frontend/backend
+          and user device are modified to cause various MitM attacks or
           Denial of Service.
         </dd>
         <dt><strong>Affected assets</strong></dt>
@@ -4383,25 +4382,24 @@ TODO delete -->
         </dd>
         <dt><strong>Mitigation, comments</strong></dt>
         <dd>
-          Use NDFE signatures to protect the NFC tag payload
-          and metadata. Additionally, harden the platform stack and 
-          communication between the web NFC frontend and backend. 
+          Use <a>NDEF signature</a>s to protect the NFC tag payload
+          and metadata. Additionally, harden the platform stack and
+          communication between the web NFC frontend and backend.
         </dd>
       </dl>
     </section>
-    
-    <section> <h4>NDFE record payload disclosure</h4>
+
+    <section> <h4>NDEF record payload disclosure</h4>
       <dl>
         <dt><strong>Threat description</strong></dt>
         <dd>
-          Confidential payload of NDFE records in-storage (stored 
-          on a NFC tag) or in-transfer between the web NFC
-          frontend/backend and user device
-          are read by unauthorized parties. 
+          Confidential payload of <a>NDEF record</a> in-storage (stored
+          on a NFC tag) or in-transfer between Web NFC and the
+          <a>NFC adapter</a> are read by unauthorized parties.
         </dd>
         <dt><strong>Affected assets</strong></dt>
         <dd>
-          Confidential NDEF message payload 
+          Confidential NDEF message payload
           in-transfer and in-storage.
         </dd>
         <dt><strong>Actors</strong></dt>
@@ -4415,7 +4413,7 @@ TODO delete -->
           mechanisms between the web NFC page and NFC tag.
         </dd>
       </dl>
-    </section>    
+    </section>
   </section>
 
 

--- a/index.html
+++ b/index.html
@@ -460,7 +460,8 @@
     encoding and format dictated by value of the <a>TNF field</a>.
   </p>
   <p class="note">
-    The [[[!NFC-RTD]]] requires that the <a>TYPE field</a> names MUST be compared in case-insensitive manner.
+    The [[[!NFC-RTD]]] requires that the <a>TYPE field</a> names MUST be
+    compared in case-insensitive manner.
   </p>
   <p>
     The <dfn>ID LENGTH field</dfn> is an unsigned 8-bit integer that denotes
@@ -849,11 +850,11 @@
 
 <section class="informative"> <h3>Use Cases</h3>
   <p>
-    A few Web NFC user scenarios are described in the
-    <a href="https://w3c.github.io/web-nfc/use-cases.html">Use Cases</a>
-    document. These user scenarios can be grouped by criteria based on
-    security, privacy and feature categories, resulting in generic flows as
-    follows.
+    A few NFC user scenarios have been enumerated
+    <a href="http://www.w3.org/2009/dap/wiki/Near_field_communications_%28NFC%29#Use_cases_submitted_to_DAP_mailing_list">
+    here</a> and in the
+    <a href="https://w3c.github.io/web-nfc/use-cases.html">Web NFC Use Cases</a>
+    document. The basic NFC interactions are the following.
   </p>
 
   <section> <h3>Reading an <a>NFC tag</a></h3>
@@ -865,9 +866,12 @@
         to tap an NFC tag, and then receives information from the tag.
       </li>
       <li>
-        Reading an <a>NFC tag</a> containing other than <a>NDEF message</a>,
-        when the {{Document}} of the <a>top-level browsing context</a> using
-        Web NFC is <a>visible</a>.
+        Reading an <a>NFC tag</a> with non-<a>NDEF</a> technology, e.g. the
+        <a>MIFARE Standard</a>, when the {{Document}} of the <a>top-level
+        browsing context</a> using Web NFC is <a>visible</a>.
+        <p class="note">
+          This use case is not supported in this version of the specification.
+        </p>
       </li>
       <li>
         Reading an <a>NFC tag</a> when no {{Document}} using Web NFC is
@@ -884,6 +888,9 @@
       The user opens a web page which can write an <a>NFC tag</a>. The write
       operations may be one of the following:
       <ol>
+        <li>
+          Writing to a non-formatted <a>NFC tag</a>.
+        </li>
         <li>
           Writing to an empty <a>NFC tag</a>.
         </li>
@@ -1002,21 +1009,6 @@
         emulation.
       </li>
     </ol>
-  </div>
-  <div>
-    This specification makes a few simplifications in what use cases
-    and data types Web NFC can handle:
-    <ul>
-      <li>
-        Expose data types already known to web browsers as
-        <a>MIME type</a>s.
-      </li>
-      <li>Use the web security model.</li>
-      <li>
-        Implementations encapsulate <a>NDEF record</a> handling and the API
-        exposes only data and control events.
-      </li>
-    </ul>
   </div>
 </section> <!-- Features -->
 
@@ -4090,6 +4082,11 @@
       The integrity of <a>NFC content</a> MAY be trusted by web sites
       and applications only if encrypted by applications, or if signed
       with an <a>NDEF signature</a>.
+    </p>
+    <p>
+      For trusting the integrity of the data exchanged via NFC, user agents MAY
+      use encrypted <a>NFC content</a> or an <a>NDEF signature</a>, with key
+      management based on Public Key Infrastructure (PKI).
     </p>
     <p>
       Security considerations for media types in general are discussed in

--- a/index.html
+++ b/index.html
@@ -4213,6 +4213,8 @@
           <a>NDEF record</a>s transferred between Web NFC and the
           <a>NFC adapter</a> and user device are modified to cause various
           MitM attacks or Denial of Service.
+          Also, <a>NDEF signature</a> records can be removed or
+          replaced along with changed content.
         </dd>
         <dt><strong>Affected assets</strong></dt>
         <dd>
@@ -4224,10 +4226,10 @@
         </dd>
         <dt><strong>Mitigation, comments</strong></dt>
         <dd>
-          Use <a>NDEF signature</a>s to protect the NFC tag payload
-          and metadata. Additionally, harden the platform stack and
-          communication between the web NFC frontend and backend.
           This threat is out of scope for Web NFC implementations.
+          Applications can use <a>NDEF signature</a>s and appropriate tools
+          (signature algorithm, certificates, security policies) to protect the
+          <a>NFC content</a>. Additionally, harden the platform stack.
         </dd>
       </dl>
     </section>
@@ -4337,7 +4339,8 @@
         In order to mitigate <a href="https://www.researchgate.net/publication/224227216_Security_Vulnerabilities_of_the_NDEF_Signature_Record_Type">
         known vulnerabilities</a> of <a>NDEF signature</a>, it is recommended
         that applications always sign a full <a>NDEF message</a> with a single
-        <a>NDEF signature</a>.
+        <a>NDEF signature</a>, and use the right tool chain and security
+        policies for creating and verifying signatures.
       </p>
     </section>
 
@@ -4424,11 +4427,15 @@
             User agents expose <a>NDEF signature</a> records without verifying
             them. It is applications' responsibility to verify signatures and
             to sign <a>NFC content</a>.
-            <p class="note">
-              Indication whether <a>NFC content</a> is trusted may be added in
-              future versions. Also, origin policies MAY be applied in order to
-              relax user prompting when a trust chain could be established.
-            </p>
+          </li>
+          <li>
+            Applications SHOULD use appropriate signature algorithms,
+            certificates and security policies for <a>NDEF signature</a>
+            creation and verification. Also, take into account the known
+            attacks agains <a>NDEF signature</a>s, for instance removing
+            <a>NDEF signature</a>, replacing <a>NDEF signature</a> along with
+             modifying the <a>NFC content</a>, reordering records by changing
+             the record <a>PAYLOAD LENGTH field</a>, etc.
           </li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -4077,26 +4077,26 @@
 <section> <h2 id="security">Security and Privacy</h2>
   <p>
     NFC technology involves multiple levels of security. Payments done with NFC
-    are considered to be at least as secure as with payment cards at hardware
-    level, but the whole software stack needs to be security hardened.
-    However, data transfers involve more threats. In order to mitigate these,
-    the NFC Forum introduced [[NDEF-SIGNATURE]].
+    are considered to be secure at hardware level, but the whole software stack
+    needs to be security hardened.
+    However, NFC data transfers involve additional threats. In order to mitigate
+    these, the NFC Forum introduced [[NDEF-SIGNATURE]].
   </p>
 
   <section> <h3>Chain of trust</h3>
     <p>
-      Web pages using Web NFC are not trusted.
-      This means that the user needs to be aware of exactly what a web page is
-      intending to do with NFC at any given moment. Implementations need to
-      make sure that when the user authorizes a method of this API, then only
+      Web sites and applications using Web NFC are not trusted.
+      This means that the user needs to be made aware of what NFC functionality
+      a web page intends to do. Implementations need to
+      make sure that when the user authorizes a method of this API, only
       that action is run, without side effects, and exactly in the context and
       the number of times the user allows the execution of NFC related
       operations, according to the algorithmic steps detailed in this
       specification.
     </p>
     <p>
-      The integrity of <a>NFC content</a> SHOULD NOT be trusted by web pages
-      unless it is encrypted by applications, or a
+      The integrity of <a>NFC content</a> SHOULD NOT be trusted by web sites
+      and applications unless it is encrypted by applications, or a
       <a>prearranged trust relationship</a> exists.
     </p>
     <p>
@@ -4176,8 +4176,7 @@
           The data is considered application specific.
           Implementations need security hardening.
           Involuntary touch is low probability due to short range and critical
-          angle for reading.
-          It’s easier to attack elsewhere (e.g. WiFi and Bluetooth).
+          angle for reading, and due to the focus requirements.
         </td>
       </tr>
       <tr>
@@ -4194,7 +4193,7 @@
       </tr>
       <tr>
         <td>
-          Malicious Web NFC tag could send an arbitrary payload to a website
+          Malicious Web NFC tag payload read by a website may inflict cause
           via a user’s device, along with a user’s existing web credentials.
           The webapp and server would need to treat that payload as completely
           untrusted.
@@ -4209,21 +4208,11 @@
       <tr>
         <td>
           A Web NFC tag could be used for leaking the user’s physical location,
-          <ul>
-            <li>
-              if the reading triggers a user’s device to navigate to a website
-              that can identify the tag and knows the tag's physical location.
-            </li>
-            <li>
-              by sending <a>NFC tag</a>s, either by directly sharing the user
-              location (when the <a>browsing context</a> has access to that),
-              or by sending information that can be used for inferring the
-              location of the user.
-            </li>
-          </ul>
+          if the reading triggers a user’s device to navigate to a website
+          that can identify the tag and knows the tag's physical location.
         </td>
         <td>
-          A Web NFC tag SHOULD NOT ever trigger a user’s device to navigate
+          A NFC tag SHOULD NOT ever trigger a user’s device to navigate
           to a website without asking permission, unless the site has been in
           the foreground or has been brought to the foreground and has been
           granted permission. User agents SHOULD take into account the
@@ -4319,11 +4308,11 @@
     <section> <h3>Sign NDEF records</h3>
       <p>
         When pushing an <a>NDEF message</a>, one, more, or all records MAY be
-        signed using <a>NDEF signature</a>.
+        signed using an <a>NDEF signature</a>.
       </p>
       <p>
         In order to build a trust chain, a Public Key Infrastructure is also
-        needed for key mananegent.
+        needed for key management.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -4088,7 +4088,7 @@
       Public Key Infrastructure (PKI).
     </p>
     <p>
-      Security considerations for media types in general are discussed in
+      Security considerations for MIME types in general are discussed in
       [[RFC2048]] and [[RFC2046]].
     </p>
   </section>
@@ -4136,7 +4136,7 @@
           <strong>Malicious web page creator</strong>: phishing user data,
           identity or other privacy sensitive attributes, destroying or
           modifying NFC tags to cause further damage through fake identities
-          and attack vectors;
+          and attack vectors.
         </li>
         <li>
           <strong>Malicious NFC tag creator</strong>: same as malicious web page
@@ -4352,7 +4352,7 @@ TODO delete -->
           Use <a>NDEF signature</a>s to protect the NFC tag payload
           and metadata. Additionally, harden the platform stack and
           communication between the web NFC frontend and backend.
-          This thhreat is out of scope for Web NFC implementations.
+          This threat is out of scope for Web NFC implementations.
         </dd>
       </dl>
     </section>
@@ -4553,7 +4553,7 @@ TODO delete -->
         <a>obtain permission</a>.
       </p>
       <p>
-        Pushing <a>NFC content</a> to an <a>NFC peer</a> SHOULD
+        Pushing <a>NFC content</a> to an <a>NFC peer</a> MUST
         <a>obtain permission</a>.
         See the [[[#writing-or-pushing-content]]] section.
       </p>
@@ -4599,7 +4599,9 @@ TODO delete -->
         <ul>
           <li>
             A <a>smart poster</a> MAY be trusted only if signed by using
-            a single <a>NDEF signature</a> record by the same issuer.
+            a single <a>NDEF signature</a> record by the same issuer and
+            it is either the first record in a message, or it is preceded by
+            another <a>NDEF signature</a>.
           </li>
           <li>
             An <a>NDEF message</a> MAY be trusted only if signed by

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <title>Web NFC</title>
   <meta charset="UTF-8">
   <link href="https://raw.githubusercontent.com/google/material-design-icons/master/device/2x_web/ic_nfc_black_48dp.png" rel="icon">
-  <script type=module src="ndef-record.js"></script>
+  <script type="module" src="ndef-record.js"></script>
   <script src='https://www.w3.org/Tools/respec/respec-w3c' async class=
   'remove'></script>
   <script class="remove">
@@ -17,8 +17,16 @@
           company: "Intel",
           companyURL: "https://intel.com/",
         },
-        { name: "Zoltan Kis", company: "Intel", companyURL: "https://intel.com/" },
-        { name: "François Beaufort", company: "Google LLC", companyURL: "https://google.com/" },
+        {
+          name: "Zoltan Kis",
+          company: "Intel",
+          companyURL: "https://intel.com/"
+        },
+        {
+          name: "François Beaufort",
+          company: "Google LLC",
+          companyURL: "https://google.com/"
+        },
       ],
       formerEditors: [
         {
@@ -151,7 +159,7 @@
 
 <!-- - - - - - - - - - - - - - -  Introduction  - - - - - - - - - - - - - - -->
 <section class="informative"> <h2>Introduction</h2>
-  <p>
+  <div>
     NFC user scenarios can be grouped as follows:
     <ul>
       <li>
@@ -180,7 +188,7 @@
        </ol>
       </li>
     </ul>
-  </p>
+  </div>
   <p>
     NFC works using magnetic induction, meaning that the reader (an active,
     powered device) will emit a
@@ -263,7 +271,7 @@
     given hardware element (NFC chip). A device may have multiple NFC
     adapters, for instance a built-in one, and one or more attached via USB.
   </p>
-  <p>
+  <div>
     An <dfn>NFC tag</dfn> is a passive NFC device.
     The <a>NFC tag</a> is powered by magnetic induction when an active NFC
     device is in proximity range. An <a>NFC tag</a> contains a single
@@ -273,7 +281,7 @@
       technologies, which require the reader and the tag to be of the same
       manufacturer. Implementations are expected to encapsulate this.
     </p>
-  </p>
+  </div>
   <p>
     An <dfn>NFC peer</dfn> is an active, powered device, which can interact
     with other devices in order to exchange data using NFC.
@@ -320,7 +328,7 @@
       <a href="https://www.nxp.com/docs/en/application-note/AN1305.pdf">
       MIFARE Classic as NFC Type MIFARE Classic Tag</a>
     </p>
-    <p>
+    <div>
       <ol>
         <li>
           <dfn>NFC Forum Type 1</dfn>: This tag is based on the ISO/IEC 14443-3A
@@ -367,7 +375,7 @@
           as defined in ISO/IEC 14443-3:2011, Part 3: Initialization and anticollision).
           The tags are rewritable and can be configured to become read-only. Memory size
           can be between `320` and `4` kbytes. Communication speed is `106` kbit/sec.
-          <p class=note>
+          <p class="note">
             <a>MIFARE Standard</a> is a not an NFC Forum type and can only be read by devices
             using NXP hardware. Support for reading and writing to tags based on the
             <a>MIFARE Standard</a> is thus non-nominative, but the type is included
@@ -375,7 +383,7 @@
           </p>
         </li>
       </ol>
-    </p>
+    </div>
     <p>
       In addition to data types standardized for <a>NDEF record</a>s by the NFC
       Forum, many commercial products such as bus cards, door openers may be based
@@ -399,19 +407,19 @@
     the data is structured, like payload size, whether the data is chunked over
     multiple records etc.
   </p>
-  <p>
+  <div>
     A generic record looks like the following:
     <ndef-record class="ndef"
       header="*,*,*,*,*,*"
       content="*,PAYLOAD LENGTH - 1 (SR) to 4 bytes,ID LENGTH (optional),TYPE (optional),ID (optional),PAYLOAD (optional)">
     </ndef-record>
-  </p>
+  </div>
   <p>
     Only the first three bytes (lines in figure) are mandatory. First the
     header byte, followed by the <a>TYPE LENGTH field</a> and <a>PAYLOAD
     LENGTH field</a>, which may both be zero.
   </p>
-  <p>
+  <div>
     The <dfn>TNF field</dfn> (bit `0-2`, type name format) indicates the format
     of the type name and is often exposed by native NFC software stacks. The
     field can take binary values denoting the following NDEF record payload types:
@@ -453,7 +461,7 @@
         <td>Reserved for future use</td>
       </tr>
     </table>
-  </p>
+  </div>
   <p>
     The <dfn>IL field</dfn> (bit `3`, id length) indicates whether an
     <a>ID LENGTH field</a> is present. If the <a>IL field</a> is `0`, then the
@@ -570,7 +578,7 @@
             containing record and when storage usage is a hard constraint. See
             <a>Smart poster</a> for an example on how local types are used.
           </p>
-          <p class=note>
+          <p class="note">
             A [=local type=] is thus defined in terms of a containing record type,
             and thus doesn't need any namespacing. For this reason the same local type
             name can be used within another record type with different meaning and
@@ -738,7 +746,7 @@
     <h4>
       MIME type records (TNF 2)
     </h4>
-    <p>
+    <div>
       The <dfn>MIME type record</dfn>s are records that store binary
       data with associated <a>MIME type</a>.
       <ndef-record
@@ -746,7 +754,7 @@
         content="*,*,*,SERIALIZED MIME TYPE,*,MIME TYPE PAYLOAD"
         short>
       </ndef-record>
-    </p>
+    </div>
     </section>
 
     <section>
@@ -764,13 +772,13 @@
       will attempt to load the URL in Chrome and it is as such not intended
       for client applications.
     </p>
-    <p>
+    <div>
       <ndef-record
         header="*,*,*,*,*,3 (ABSOLUTE URL)"
         content="*,*,*,ABSOLUTE URL STRING,*,PAYLOAD (optional/ignored)"
         short>
       </ndef-record>
-    </p>
+    </div>
     </section>
 
     <section>
@@ -787,13 +795,13 @@
       for instance `"urn:nfc:ext:w3.org:atype"`, stored as `"w3.org:atype"`
       in the <a>TYPE field</a>.
     </p>
-    <p>
+    <div>
       <ndef-record
         header="*,*,*,*,*,4 (EXTERNAL)"
         content="*,*,*,EXTERNAL TYPE (eg. w3.org:member),*,*"
         short>
       </ndef-record>
-    </p>
+    </div>
     </section>
 
     <section>
@@ -807,13 +815,13 @@
       The [[NFC-NDEF]] specification recommends that <a>NDEF</a> parsers store
       or forward the payload without processing it.
     </p>
-    <p>
+    <div>
       <ndef-record
         header="*,*,*,*,*,5 (UNKNOWN)"
         content="0,*,*,_,*,*"
         short>
       </ndef-record>
-    </p>
+    </div>
   </section>
   <section>
     <h4>
@@ -849,7 +857,7 @@
         </li>
       </ul>
     </div>
-    <p>
+    <div>
       First record:
       <ndef-record
         header="1,0,1,1,0,*"
@@ -870,7 +878,7 @@
         content="0,PAYLOAD LENGTH FOR THIS RECORD,_,_,_,*"
         short>
       </ndef-record>
-    </p>
+    </div>
     <p>
       Any implementation of Web NFC MUST transparently expose chunked records
       as single logical records.
@@ -910,8 +918,9 @@
       </li>
     </ol>
   </section>
+
   <section> <h3>Writing to an <a>NFC tag</a></h3>
-    <p>
+    <div>
       The user opens a web page which can write an <a>NFC tag</a>. The write
       operations may be one of the following:
       <ol>
@@ -933,12 +942,13 @@
           generic tag).
         </li>
       </ol>
-    </p>
+    </div>
     <p class="note">
       Note that an NFC write operation to an <a>NFC tag</a> always involves
       also a read operation.
     </p>
   </section>
+
   <section> <h3>Pushing data to an <a>NFC peer</a> device</h3>
     <p>
       In general, pushing data to another NFC capable device requires that
@@ -954,6 +964,7 @@
       then the content is delivered to the page through the <a>NDEFReadingEvent</a>.
     </p>
   </section>
+
   <section> <h3>Handover to another wireless connection type</h3>
     <p>
       NFC supports handover protocols to Bluetooth or WiFi connectivity for
@@ -966,6 +977,7 @@
       This use case is not supported in this version of the specification.
     </p>
   </section>
+
   <section> <h3>Payment scenarios</h3>
     <p>
       Payment scenarios with Web NFC generally do not refer to supporting
@@ -985,6 +997,7 @@
       This use case is not supported in this version of the specification.
     </p>
   </section>
+
   <section> <h3>Support for multiple NFC adapters</h3>
     <p>
       Users may attach one or more external <a>NFC adapter</a>s to their
@@ -995,7 +1008,8 @@
 </section> <!-- Use Cases -->
 
 <section class="informative"> <h3>Features</h3>
-  <p>High level features for the Web NFC specification include the following:
+  <div>
+    High level features for the Web NFC specification include the following:
     <ol>
       <li>
         Support devices with single or multiple <a>NFC adapter</a>s.
@@ -1028,8 +1042,8 @@
         emulation.
       </li>
     </ol>
-  </p>
-  <p>
+  </div>
+  <div>
     This specification makes a few simplifications in what use cases
     and data types Web NFC can handle:
     <ul>
@@ -1043,7 +1057,7 @@
         exposes only data and control events.
       </li>
     </ul>
-  </p>
+  </div>
 </section> <!-- Features -->
 
 <!-- - - - - - - - - - - - - - Usage Examples - - - - - - - - - - - - - - -->
@@ -1475,171 +1489,6 @@
   </section>
 </section> <!-- Usage examples -->
 
-<!-- - - - - - - - - - - - - Security and Privacy - - - - - - - - - - - - - -->
-<section> <h2 id="security">Security and Privacy</h2>
-  <p>
-    The trust model, attacker model, threat model and possible mitigation
-    proposals for Web NFC are presented in the
-    <a href="http://w3c.github.io/web-nfc/security-privacy.html">
-    Security and Privacy</a> document. This section presents the chosen
-    security and privacy model through normative requirements to
-    implementations.
-  </p>
-
-  <section> <h3>Chain of trust</h3>
-  <p>
-    Web pages using Web NFC are not trusted.
-    This means that the user needs to be aware of exactly what a web page is
-    intending to do with NFC at any given moment. Implementations need to
-    make sure that when the user authorizes a method of this API, then only that
-    action is run, without side effects, and exactly in the context and the
-    number of times the user allows the execution of NFC related operations,
-    according to the algorithmic steps detailed in this specification.
-  </p>
-  <p>
-    The integrity of <a>NFC content</a> SHOULD NOT be trusted when
-    used for implementing security policies, for instance the authenticity of
-    <a>record identifier</a>, unless a <a>prearranged trust relationship</a> exists.
-  </p>
-  <p>
-    Security considerations for media types in general are discussed in
-    [[RFC2048]] and [[RFC2046]].
-  </p>
-  </section>
-
-  <section> <h3>Threats</h3>
-  <p>
-    The main threats are summarized in the
-    <a href="http://w3c.github.io/web-nfc/security-privacy.html#threats-and-possible-solutions">
-    Security and Privacy</a> document.
-  </p>
-  <p>
-    In this specification the following threats are handled with the highest
-    priority:
-    <ul>
-      <li>
-        User data privacy: involuntary sharing of user data (such as location,
-        contacts, personal data, etc) from an NFC-capable device such as a
-        phone, tablet, or PC.
-      </li>
-      <li>
-        Protecting existing <a>NFC tag</a>s from being overwritten by malicious
-        web pages.
-      </li>
-    </ul>
-  </p>
-  </section>
-
-  <section> <h3>Permissions and user prompts</h3>
-  <p>
-    This specification attempts to minimize user prompting and uses implicit
-    security policies to address the
-    <a href="http://w3c.github.io/web-nfc/security-privacy.html#threats-and-possible-solutions">
-    threats</a>.
-    However, this specification does not describe, nor does it
-    mandate specific user prompting policies. The term <a>obtain permission</a>
-    is used for acquiring trust for a given operation.
-  </p>
-  <p class="note">
-    The [[[PERMISSIONS]]] API is suggested to be used by
-    UAs for implementing NFC related [[[PERMISSIONS]]] in order to minimize
-    the need for user prompting.
-  </p>
-  <p>
-    All <a>expressed permission</a>s that are preserved beyond the current
-    browsing session MUST be revocable.
-  </p>
-  </section>
-
-  <section class="informative"> <h3>Security policies</h3>
-    <p>
-      This section summarizes the security policies which are specified as
-      normative requirements in the respective algorithms of this
-      specification.
-    </p>
-    <section> <h4>Secure Context</h4>
-      <p>
-        Only <a>secure contexts</a> are allowed to access <a>NFC content</a>.
-        Browsers may ignore this rule for development purposes only.
-      </p>
-    </section>
-    <section> <h4>Visible document</h4>
-      <p>
-        Web NFC functionality is allowed only for the {{Document}} of the
-        <a>top-level browsing context</a>, which must be
-        <dfn data-cite="PAGE-VISIBILITY#dom-visibilitystate-visible">visible</dfn>.
-      </p>
-      <p>
-        This also means that UAs should block access to the NFC radio if
-        the display is off or the device is locked.
-        For backgrounded web pages, receiving and pushing <a>NFC content</a>
-        must be <a id="#nfc-suspended">suspended</a>.
-      </p>
-    </section>
-    <section> <h4>Permissions controls</h4>
-      <p>
-        Making an <a>NFC tag</a> read-only must <a>obtain permission</a>, or
-        otherwise fail.
-      </p>
-      <p>
-        Setting up listeners for reading <a>NFC content</a> should
-        <a>obtain permission</a>.
-      </p>
-      <p>
-        The process of reading an <a>NDEF message</a> does not need to
-        <a>obtain permission</a>.
-      </p>
-      <p>
-        Pushing <a>NFC content</a> to an <a>NFC peer</a> does not need to
-        <a>obtain permission</a>, but the other rules in this section apply.
-        See the [[[#writing-or-pushing-content]]] section.
-      </p>
-      <p>
-        Pushing an <a>NDEF message</a> to an <a>NFC tag</a> does not need to
-        <a>obtain permission</a>, if the existing <a>NDEF message</a> only
-        contains <a>NDEF record</a>s without <a>ID field</a>s, or with <a>
-        ID field</a>s matching the [=host/registrable domain=] of the
-        <a>current settings object</a>'s origin.
-        Otherwise the UA must <a>obtain permission</a> for pushing
-        <a>NFC content</a> which overwrites existing information.
-        See also the [[[#writing-or-pushing-content]]] section.
-      </p>
-      <p>
-        Since all local content that a web page has access to can be shared with
-        NFC, the user needs to be clearly aware about the permissions granted
-        to the web page using Web NFC.
-      </p>
-    </section>
-    <section> <h4>Store site URL as record identifier when writing data</h4>
-      <p>
-        When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
-        <a data-cite="dom#concept-host-serializer">serialized</a>,
-        of the <a>current settings object</a> must be stored as the <a>record
-        identifier</a> in each top-level <a>NDEF Record</a>.
-      </p>
-    </section>
-    <section> <h4>Warn risk of physical location leak</h4>
-      <p>
-        When listening for and pushing <a>NFC content</a>,
-        the UA may warn the user that the given <a>origin</a> may be able to
-        infer physical location.
-      </p>
-    </section>
-    <section> <h4>Restrict automatic handling</h4>
-      <p>
-        The payload data on <a>NFC content</a> is untrusted, and must not be used
-        by the UA to do automatic handling such as opening a web page
-        with a URL found in an <a>NFC tag</a>, unless the user approves that.
-      </p>
-    </section>
-      <!--p>
-        For Bluetooth and WiFi handover (supported in later versions),
-        the user should have to grant access to the secondary API and must be
-        able to properly understand what they are granting.
-      </p-->
-  </section> <!-- Policies -->
-</section> <!-- Security and Privacy  -->
-
 <!-- - - - - - - - - - - - - Data representation - - - - - - - - - - - - - -->
 <section> <h2>Data Representation</h2>
   <section> <h3>The <dfn>NDEFMessage</dfn> interface</h3>
@@ -1742,7 +1591,7 @@
     <p>
       The <dfn>recordType</dfn> property represents the <a>NDEF record</a> types.
     </p>
-    <p>
+    <div>
       The <dfn>id</dfn> property represents the <a>record identifier</a>, which is an
       absolute or relative URL. The required uniqueness of the identifier is
       guaranteed by the generator, as such only absolute URLs based on the origin
@@ -1757,12 +1606,12 @@
           by a <a>path-absolute-URL string</a>.
         </li>
       </ul>
-      <div class=note>
+      <p class=note>
         The NFC NDEF specifications uses the terms "message identifier" and "payload identifier"
         instead of <a>record identifier</a>, but the identifier is tied to each record and not
         the message (collection of records), and it may be present when no payload is.
-      </div>
-    </p>
+      </p>
+    </div>
     <p>
       The <dfn>encoding</dfn> attribute represents the
       [=encoding/name|encoding name=] used for encoding the payload in the
@@ -1799,7 +1648,7 @@
       with its <a>record type</a> <dfn>recordType</dfn>, and optional <a>record identifier</a>
       <dfn>id</dfn> and payload data <dfn>data</dfn>.
     </p>
-    <p data-dfn-for="NDEFRecordInit">
+    <div data-dfn-for="NDEFRecordInit">
       Additionally, there are additional optional fields that are only applicable
       for certain <a>record types</a>:
       <ul>
@@ -1811,7 +1660,7 @@
           and [=language tag=] <dfn>lang</dfn>.
         </li>
       </ul>
-    </p>
+    </div>
     <p>
       The mapping from data types of an
       <a>NDEFRecordInit</a> to <a>NDEF record</a> types is presented
@@ -2246,7 +2095,7 @@
     <tbody data-link-for="NDEFScanOptions">
      <tr>
       <td><dfn>[[\Id]]</dfn></td>
-      <td>An empty <a>string</a>.
+      <td>An empty <a>string</a>.</td>
       <td>
         The {{NDEFScanOptions}}.<a>id</a> value.
       </td>
@@ -2260,7 +2109,7 @@
      </tr>
      <tr>
       <td><dfn>[[\MediaType]]</dfn></td>
-      <td>An empty <a>string</a>.
+      <td>An empty <a>string</a>.</td>
       <td>
         The {{NDEFScanOptions}}.<a>mediaType</a> value.
       </td>
@@ -2389,7 +2238,7 @@
   </section>
 
   <section><h3>Aborting pending push operation</h3>
-  <p>
+  <div>
     To attempt to <dfn>abort a pending push operation</dfn> on an
     <a>environment settings object</a>, perform the following steps:
     <ol class=algorithm>
@@ -2408,7 +2257,7 @@
         </p>
       </li>
     </ol>
-  </p>
+  </div>
   </section>
 
   <section><h3>Releasing NFC</h3>
@@ -2655,38 +2504,39 @@
                   implementation might be unable to support the requested
                   operation.
                 </p>
-                <li>
-                  Let |output| be the notation for the <a>NDEF message</a>
-                  to be created by UA, as the result of passing
-                  |message| to <a>create NDEF message</a>.
-                  If this throws an exception, reject |p| with that
-                  exception and abort these steps.
-                </li>
-                <li>
-                  Attempt to <a>abort a pending push operation</a>.
-                  <p class="note">
-                    A push replaces all previously configured push operations.
-                  </p>
-                </li>
-                <li>
-                  Set `this`.[[\PushOptions]] to |options|.
-                </li>
-                <li>
-                  Set `this`.[[\PushMessage]] to |output|.
-                </li>
-                <li>
-                  Set <a>pending push tuple</a> to (`this`, |p|).
-                </li>
-                <li>
-                  Run the <a>start the NFC push</a> steps whenever an
-                  <a>NFC device</a> |device| comes within communication range.
-                </li>
+              </li>
+              <li>
+                Let |output| be the notation for the <a>NDEF message</a>
+                to be created by UA, as the result of passing
+                |message| to <a>create NDEF message</a>.
+                If this throws an exception, reject |p| with that
+                exception and abort these steps.
+              </li>
+              <li>
+                Attempt to <a>abort a pending push operation</a>.
+                <p class="note">
+                  A push replaces all previously configured push operations.
+                </p>
+              </li>
+              <li>
+                Set `this`.[[\PushOptions]] to |options|.
+              </li>
+              <li>
+                Set `this`.[[\PushMessage]] to |output|.
+              </li>
+              <li>
+                Set <a>pending push tuple</a> to (`this`, |p|).
+              </li>
+              <li>
+                Run the <a>start the NFC push</a> steps whenever an
+                <a>NFC device</a> |device| comes within communication range.
                 <p class="note">
                   If <a>NFC is suspended</a>, continue waiting until promise is
                   aborted by the user or an <a>NFC device</a> comes within
                   communication range.
                 </p>
-              </ol>
+              </li>
+            </ol>
             </li>
           </li>
         </ol>
@@ -2798,7 +2648,7 @@
     </section>
 
     <section><h3>Obtaining push permission</h3>
-      <p>
+      <div>
         To <dfn>obtain push permission</dfn>, run these steps:
         <ol class=algorithm>
           <li>
@@ -2836,7 +2686,7 @@
             Return `false`.
           </li>
         </ol>
-      </p>
+      </div>
     </section>
   </section> <!-- Writing or pushing content -->
 
@@ -2943,37 +2793,38 @@
                     </li>
                   </ul>
                 </dl>
-                <li>
-                  If |message| is of type {{NDEFMessageInit}} and its
-                  |id:string| is not `null`:
-                  <ul>
-                    <li>
-                      Set |identifier| to the result of invoking
-                      <a>create a record identifier</a> given |id|.
-                      If this throws an exception, re-[= exception/throw =] it.
-                    </li>
-                    <li>
-                      Set |ndef|'s <a>IL field</a> to `1`.
-                    </li>
-                    <li>
-                      Set |ndef|'s <a>ID LENGTH field</a> to the length of |identifier|.
-                    </li>
-                    <li>
-                      Set |ndef|'s <a>ID field</a> to |identifier|.
-                    </li>
-                  </ul>
-                </li>
-                <li>
-                  Add |ndef| to |output|.
-                </li>
-              </li> <!-- converting each record -->
+              </li>
+              <li>
+                If |message| is of type {{NDEFMessageInit}} and its
+                |id:string| is not `null`:
+                <ul>
+                  <li>
+                    Set |identifier| to the result of invoking
+                    <a>create a record identifier</a> given |id|.
+                    If this throws an exception, re-[= exception/throw =] it.
+                  </li>
+                  <li>
+                    Set |ndef|'s <a>IL field</a> to `1`.
+                  </li>
+                  <li>
+                    Set |ndef|'s <a>ID LENGTH field</a> to the length of |identifier|.
+                  </li>
+                  <li>
+                    Set |ndef|'s <a>ID field</a> to |identifier|.
+                  </li>
+                </ul>
+              </li>
+              <li>
+                Add |ndef| to |output|.
+              </li>
+              <!-- converting each record -->
             </ol>
           </li> <!-- converting message -->
         </ol>
       </section>
 
       <section><h3>Mapping empty record to NDEF</h3>
-      <p>
+      <div>
         To <dfn>map empty record to NDEF</dfn> given a |record:NDEFRecordInit|, run
         these steps:
         <ol class=algorithm>
@@ -3000,11 +2851,11 @@
             Return |ndef|.
           </li>
         </ol>
-      </p>
+      </div>
       </section>
 
       <section><h3>Mapping string to NDEF</h3>
-      <p>
+      <div>
         To <dfn>map text to NDEF</dfn> given a |record:NDEFRecordInit|, run these
         steps:
         <p class="note">
@@ -3064,6 +2915,7 @@
               <li>
                 If |languageLength| cannot be stored in 6 bit (|languageLength| > 63),
                 [= exception/throw =] a {{SyntaxError}}.
+              </li>
               <li>
                 Set bit `5` to bit `0` to |languageLength|.
               </li>
@@ -3133,11 +2985,11 @@
             Return |ndefRecord|.
           </li>
         </ol>
-      </p>
+      </div>
       </section>
 
       <section><h3>Mapping URL to NDEF</h3>
-      <p>
+      <div>
         To <dfn>map a URL to NDEF</dfn> given a |record:NDEFRecordInit|, run these
         steps:
         <ol class=algorithm>
@@ -3223,11 +3075,11 @@
             Return |ndefRecord|.
           </li>
         </ol>
-      </p>
+      </div>
       </section>
 
       <section><h3>Mapping binary data to NDEF</h3>
-      <p>
+      <div>
         To <dfn>map binary data to NDEF</dfn> given a |record:NDEFRecordInit|,
         run these steps:
         <ol class=algorithm>
@@ -3279,11 +3131,11 @@
             Return |ndefRecord|.
           </li>
         </ol>
-      </p>
+      </div>
       </section>
 
       <section><h3>Mapping external data to NDEF</h3>
-      <p>
+      <div>
         To <dfn>map external data to NDEF</dfn> given a |record:NDEFRecordInit|,
         run these steps:
         <ol class=algorithm>
@@ -3327,11 +3179,11 @@
             Return |ndefRecord|.
           </li>
         </ol>
-      </p>
+      </div>
       </section>
 
       <section><h3>Mapping local type to NDEF</h3>
-      <p>
+      <div>
         To <dfn>map local type to NDEF</dfn> given a |record:NDEFRecordInit|,
         run these steps:
         <ol class=algorithm>
@@ -3381,11 +3233,11 @@
             Return |ndefRecord|.
           </li>
         </ol>
-      </p>
+      </div>
       </section>
 
       <section><h3>Creating a record identifier</h3>
-      <p>
+      <div>
         To <dfn>create a record identifier</dfn> given URL string |id:string|,
         run these steps:
         <ol class=algorithm>
@@ -3422,7 +3274,7 @@
             Return |identifier|.
           </li>
         </ol>
-      </p>
+      </div>
       </section>
   </section> <!-- creating content -->
 
@@ -3448,7 +3300,7 @@
     </p>
 
     <section> <h3>Match patterns</h3>
-      <p>
+      <div>
         A <dfn>match pattern</dfn> is defined by the following ABNF:
         <pre class="abnf">
           match-pattern  = top-level-type "/" [ tree "." ] subtype [ "+" suffix ] [ ";" parameters ]
@@ -3462,7 +3314,7 @@
         "`application/calendar+json`", but does not match
         "`application/json`". The pattern
         "`*/*json`", on the other hand, matches both.
-      </p>
+      </div>
     </section>
     <section> <h3>URL patterns</h3>
         A <dfn>URL pattern</dfn> is a <a>URL record</a> that can be used to match
@@ -3470,7 +3322,7 @@
         A <dfn>valid URL pattern</dfn> is a valid <a>URL record</a> whose
         [= url/scheme =] component is equal to "`https`".
 
-      <p>
+      <div>
         A <a>URL pattern</a>'s [= url/scheme =], [= url/host =]
         and [= url/path =] components that are used by the
         <a href="#dfn-match-record-identifier-with-url-pattern">URL pattern match algorithm</a>
@@ -3498,7 +3350,7 @@
             </td>
           </tr>
         </table>
-      </p>
+      </div>
 
       <p class="note">
         For example, '`https://mydomain.com/*`' will match
@@ -3574,7 +3426,7 @@
       <p>
         Incoming <a>NFC content</a> is matched using {{NDEFReader}} instances.
       </p>
-      <p>
+      <div>
         When the <dfn>NDEFReader.scan</dfn> method is invoked, the UA
         MUST run the following
         <dfn id="steps-listen">NFC listen algorithm</dfn>:
@@ -3685,8 +3537,8 @@
             </ol>
           </li>
         </ol>
-      </p>
-      <p>
+      </div>
+      <div>
         To <dfn>obtain reading permission</dfn>, run these steps:
         <ol>
           <li>
@@ -3720,7 +3572,7 @@
             Return `true`.
           </li>
         </ol>
-      </p>
+      </div>
     </section>
 
     <section><h3>The NFC reading algorithm</h3>
@@ -3870,13 +3722,14 @@
               <li>
                 If this is the first iteration of these sub-steps and |messageBegin| is `false`,
                 return |records|.
+              </li>
               <li>
                 Let |messageEnd:boolean| (<a>ME field</a>) be bit 6 of |header|.
               </li>
-              <div class=note>
+              <p class=note>
                 As chunked records are not allowed as sub records, ignore bit 5
                 (<a>CF field</a>) is ignored.
-              </div>
+              </p>
               <li>
                 Let |shortRecord:boolean| (<a>SR field</a>) be bit 4 of |header|.
               </li>
@@ -3926,6 +3779,7 @@
           </li>
           <li>
             If |messageEnd| is `true`, abort these sub-steps.
+          </li>
         </ol>
       </li>
       <li>
@@ -3935,7 +3789,7 @@
   </section>
 
   <section><h3>Parsing NDEF records</h3>
-  <p>
+  <div>
     To <dfn>parse an NDEF record</dfn> given |ndef| into a
     |record:NDEFRecord|, run these steps:
     <ol class=algorithm>
@@ -3997,6 +3851,7 @@
         then set |record| to the result of running <a>parse an NDEF external type record</a>
         on |ndef|, or make sure that the underlying platform provides equivalent values
         to the |record| object's properties.
+      </li>
       <li>
         Otherwise, if |ndef|'s |typeNameField| is `5` (<a>unknown record</a>)
         then set |record| to the result of running <a>parse an NDEF unknown record</a>
@@ -4004,11 +3859,11 @@
         to the |record| object's properties.
       </li>
     </ol>
-  </p>
+  </div>
   </section>
 
   <section><h3>Parsing NDEF well-known `T` records</h3>
-  <p>
+  <div>
     To <dfn>parse an NDEF text record</dfn> given a |ndefRecord| into a
     |record:NDEFRecord|, run these steps:
     <ol class=algorithm>
@@ -4054,7 +3909,7 @@
         return |record|.
       </li>
     </ol> <!-- parsing NDEF text record -->
-  </p>
+  </div>
   <aside class="note" data-link-for="NDEFRecord">
     <p>
       The Unicode standard defines multiple encodings like UTF-8, UTF-16 and UTF-32.
@@ -4098,7 +3953,7 @@
   </section>
 
   <section><h3>Parsing NDEF well-known `U` records</h3>
-  <p>
+  <div>
     To <dfn>parse an NDEF URL record</dfn> given a |ndefRecord| into a
     |record:NDEFRecord|, run these steps:
     <ol class=algorithm>
@@ -4135,11 +3990,11 @@
         return |record|.
       </li>
     </ol> <!-- parsing NDEF URL record -->
-  </p>
+  </div>
   </section>
 
   <section><h3>Parsing NDEF well-known `Sp` records</h3>
-  <p>
+  <div>
     To <dfn>parse an NDEF smart-poster record</dfn> given a |ndefRecord| into a
     |record:NDEFRecord|, run these steps:
     <ol class=algorithm>
@@ -4160,11 +4015,11 @@
         return |record|.
       </li>
     </ol>  <!-- parsing NDEF smart-poster record -->
-  </p>
+  </div>
   </section>
 
   <section><h3>Parsing NDEF MIME type records</h3>
-    <p>
+    <div>
       To <dfn>parse an NDEF MIME type record</dfn> given a |ndefRecord| into a
       |record:NDEFRecord|, run these steps:
       <ol class=algorithm>
@@ -4187,11 +4042,11 @@
           return |record|.
         </li>
       </ol> <!-- parsing NDEF MIME type record -->
-    </p>
+    </div>
   </section>
 
   <section><h3>Parsing NDEF absolute-URL records</h3>
-    <p>
+    <div>
       To <dfn>parse an NDEF absolute-URL record</dfn> given a |ndefRecord| into a
       |record:NDEFRecord|, run these steps:
       <ol class=algorithm>
@@ -4209,11 +4064,11 @@
           return |record|.
         </li>
       </ol>  <!-- parsing NDEF absolute URI record -->
-    </p>
+    </div>
   </section>
 
   <section><h3>Parsing NDEF external type records</h3>
-    <p>
+    <div>
       To <dfn>parse an NDEF external type record</dfn> given a |ndefRecord| into a
       |record:NDEFRecord|, run these steps:
       <ol class=algorithm>
@@ -4231,11 +4086,11 @@
           return |record|.
         </li>
       </ol>  <!-- parsing NDEF external type record -->
-    </p>
+    </div>
   </section>
 
   <section><h3>Parsing NDEF unknown type records</h3>
-    <p>
+    <div>
       To <dfn>parse an NDEF unknown record</dfn> given a |ndefRecord| into a
       |record:NDEFRecord|, run these steps:
       <ol class=algorithm>
@@ -4253,9 +4108,175 @@
           return |record|.
         </li>
       </ol>  <!-- parsing NDEF unknown record -->
-    </p>
+    </div>
   </section>
 </section>
+</section>
+
+<!-- - - - - - - - - - - - - Security and Privacy - - - - - - - - - - - - - -->
+<section> <h2 id="security">Security and Privacy</h2>
+  <p>
+    The trust model, attacker model, threat model and possible mitigation
+    proposals for Web NFC are presented in the
+    <a href="http://w3c.github.io/web-nfc/security-privacy.html">
+    Security and Privacy</a> document. This section presents the chosen
+    security and privacy model through normative requirements to
+    implementations.
+  </p>
+
+  <section> <h3>Chain of trust</h3>
+  <p>
+    Web pages using Web NFC are not trusted.
+    This means that the user needs to be aware of exactly what a web page is
+    intending to do with NFC at any given moment. Implementations need to
+    make sure that when the user authorizes a method of this API, then only that
+    action is run, without side effects, and exactly in the context and the
+    number of times the user allows the execution of NFC related operations,
+    according to the algorithmic steps detailed in this specification.
+  </p>
+  <p>
+    The integrity of <a>NFC content</a> SHOULD NOT be trusted when
+    used for implementing security policies, for instance the authenticity of
+    <a>record identifier</a>, unless a <a>prearranged trust relationship</a> exists.
+  </p>
+  <p>
+    Security considerations for media types in general are discussed in
+    [[RFC2048]] and [[RFC2046]].
+  </p>
+  </section>
+
+  <section> <h3>Threats</h3>
+  <p>
+    The main threats are summarized in the
+    <a href="http://w3c.github.io/web-nfc/security-privacy.html#threats-and-possible-solutions">
+    Security and Privacy</a> document.
+  </p>
+  <div>
+    In this specification the following threats are handled with the highest
+    priority:
+    <ul>
+      <li>
+        User data privacy: involuntary sharing of user data (such as location,
+        contacts, personal data, etc) from an NFC-capable device such as a
+        phone, tablet, or PC.
+      </li>
+      <li>
+        Protecting existing <a>NFC tag</a>s from being overwritten by malicious
+        web pages.
+      </li>
+    </ul>
+  </div>
+  </section>
+
+  <section> <h3>Permissions and user prompts</h3>
+  <p>
+    This specification attempts to minimize user prompting and uses implicit
+    security policies to address the
+    <a href="http://w3c.github.io/web-nfc/security-privacy.html#threats-and-possible-solutions">
+    threats</a>.
+    However, this specification does not describe, nor does it
+    mandate specific user prompting policies. The term <a>obtain permission</a>
+    is used for acquiring trust for a given operation.
+  </p>
+  <p class="note">
+    The [[[PERMISSIONS]]] API is suggested to be used by
+    UAs for implementing NFC related [[[PERMISSIONS]]] in order to minimize
+    the need for user prompting.
+  </p>
+  <p>
+    All <a>expressed permission</a>s that are preserved beyond the current
+    browsing session MUST be revocable.
+  </p>
+  </section>
+
+  <section class="informative"> <h3>Security policies</h3>
+    <p>
+      This section summarizes the security policies which are specified as
+      normative requirements in the respective algorithms of this
+      specification.
+    </p>
+    <section> <h4>Secure Context</h4>
+      <p>
+        Only <a>secure contexts</a> are allowed to access <a>NFC content</a>.
+        Browsers may ignore this rule for development purposes only.
+      </p>
+    </section>
+    <section> <h4>Visible document</h4>
+      <p>
+        Web NFC functionality is allowed only for the {{Document}} of the
+        <a>top-level browsing context</a>, which must be
+        <dfn data-cite="PAGE-VISIBILITY#dom-visibilitystate-visible">visible</dfn>.
+      </p>
+      <p>
+        This also means that UAs should block access to the NFC radio if
+        the display is off or the device is locked.
+        For backgrounded web pages, receiving and pushing <a>NFC content</a>
+        must be <a id="#nfc-suspended">suspended</a>.
+      </p>
+    </section>
+    <section> <h4>Permissions controls</h4>
+      <p>
+        Making an <a>NFC tag</a> read-only must <a>obtain permission</a>, or
+        otherwise fail.
+      </p>
+      <p>
+        Setting up listeners for reading <a>NFC content</a> should
+        <a>obtain permission</a>.
+      </p>
+      <p>
+        The process of reading an <a>NDEF message</a> does not need to
+        <a>obtain permission</a>.
+      </p>
+      <p>
+        Pushing <a>NFC content</a> to an <a>NFC peer</a> does not need to
+        <a>obtain permission</a>, but the other rules in this section apply.
+        See the [[[#writing-or-pushing-content]]] section.
+      </p>
+      <p>
+        Pushing an <a>NDEF message</a> to an <a>NFC tag</a> does not need to
+        <a>obtain permission</a>, if the existing <a>NDEF message</a> only
+        contains <a>NDEF record</a>s without <a>ID field</a>s, or with <a>
+        ID field</a>s matching the [=host/registrable domain=] of the
+        <a>current settings object</a>'s origin.
+        Otherwise the UA must <a>obtain permission</a> for pushing
+        <a>NFC content</a> which overwrites existing information.
+        See also the [[[#writing-or-pushing-content]]] section.
+      </p>
+      <p>
+        Since all local content that a web page has access to can be shared with
+        NFC, the user needs to be clearly aware about the permissions granted
+        to the web page using Web NFC.
+      </p>
+    </section>
+    <section> <h4>Store site URL as record identifier when writing data</h4>
+      <p>
+        When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
+        <a data-cite="dom#concept-host-serializer">serialized</a>,
+        of the <a>current settings object</a> must be stored as the <a>record
+        identifier</a> in each top-level <a>NDEF Record</a>.
+      </p>
+    </section>
+    <section> <h4>Warn risk of physical location leak</h4>
+      <p>
+        When listening for and pushing <a>NFC content</a>,
+        the UA may warn the user that the given <a>origin</a> may be able to
+        infer physical location.
+      </p>
+    </section>
+    <section> <h4>Restrict automatic handling</h4>
+      <p>
+        The payload data on <a>NFC content</a> is untrusted, and must not be used
+        by the UA to do automatic handling such as opening a web page
+        with a URL found in an <a>NFC tag</a>, unless the user approves that.
+      </p>
+    </section>
+      <!--p>
+        For Bluetooth and WiFi handover (supported in later versions),
+        the user should have to grant access to the secondary API and must be
+        able to properly understand what they are granting.
+      </p-->
+  </section> <!-- Policies -->
+</section> <!-- Security and Privacy  -->
 
 <section id="idl-index" class="appendix">
   <!-- All the Web IDL will magically appear here -->
@@ -4274,6 +4295,7 @@
     <a href="https://github.com/w3c/nfc">work</a>
     on exposing NFC to the web platform, and for their support for the current
     approach.
+  </p>
 </section>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -4295,23 +4295,16 @@
   </section>
 
   <section class="informative"> <h2>Security mechanisms for implementations</h2>
-    <p>
-      In order to support security policies concerning Web NFC, the following
-      mechanisms are recommended for implementations.
-    </p>
     <section> <h3><dfn>Obtaining permission</dfn></h3>
       <p>
-        Implementations SHOULD use one or more of the following mechanisms to
-        <a>obtain permission</a>, for instance an explicit permission given
-        by the user. The [[[PERMISSIONS]]] API is suggested to be used by UAs
+        Implementations SHOULD use a mechanism to <a>obtain permission</a>,
+        for instance an explicit permission given by the user.
+        The [[[PERMISSIONS]]] API is suggested to be used by UAs
         for implementing NFC related permissions.
       </p>
     </section>
   </section>
   <section class="informative"> <h2>Security mechanisms for applications</h2>
-    <p>
-      The following mechanisms are recommended to be used by applications.
-    </p>
     <section> <h3>Encrypting <a>NFC content</a></h3>
       <p>
         For trusting the confidentiality of the data exchanged via NFC,
@@ -4358,7 +4351,7 @@
     <section> <h4>Secure Context</h4>
       <p>
         Only <a>secure contexts</a> are allowed to access <a>NFC content</a>.
-        Browsers may ignore this rule for development purposes only.
+        Browsers MAY ignore this rule for development purposes only.
       </p>
     </section>
 
@@ -4440,11 +4433,13 @@
         </ul>
       </div>
     </section>
+    <!-- TODO: add later
     <p class="note">
       For Bluetooth and WiFi handover (supported in later versions),
       the user should have to grant access to the secondary API and must be
       able to properly understand what they are granting.
     </p>
+    -->
   </section> <!-- Policies -->
 </section> <!-- Security and Privacy  -->
 

--- a/index.html
+++ b/index.html
@@ -4098,25 +4098,26 @@
       Assets to be protected include the following:
       <ul>
         <li>
-          <strong>NDEF message records, including payload and associated metadata
-          </strong> in-transfer and in-storage (when tag is being overwritten via
-          Web NFC triggered action), against data disclosure or data modification.
+          <strong>NDEF message</strong> as a whole,
+          <strong>NDEF records</strong> (including payload and header) in
+          particular, either in-transfer or in-storage state,
+          when they are being overwritten by a Web NFC triggered operation,
+          against data disclosure and data modification.
           This also includes Denial of Service attacks against a solution
           deployed with NFC tags (e.g. a malicious actor destroying tags linked
           to a solution).
         </li>
         <li>
           <strong>User identity or other privacy sensitive attributes</strong>
-          that can be directly or indirectly determined by using NFC by tag
-          content creator or exposed to a web page using Web NFC. They can be
-          used directly or leaking forward to third parties. Examples are user
-          location, user device identifier and user identifier.
+          that can be directly or indirectly determined by using Web NFC, by the
+          <a>NFC content</a> creator by a web site using Web NFC.
+          This data could be used directly or leaked forward to third parties. Examples are user location, device identifiers and user identifiers.
         </li>
         <li>
           <strong>User data</strong> exposed to a web page using Web NFC.
           While web page might collect user data using other means than
-          web NFC protocol, it might embed this data into NDEF records
-          shared via Web NFC.
+          Web NFC, it might embed this data into NDEF records and share via
+          Web NFC.
         </li>
         <li>
           <strong>Integrity of user device</strong>.
@@ -4132,23 +4133,26 @@
       The following attacker patterns have been considered:
       <ul>
         <li>
-          Malicious web page creator: phishing user data, identity or
-          other privacy sensitive attributes, destroying or modifying NFC tags to
-          cause further damage through fake identities and attack vectors;
+          <strong>Malicious web page creator</strong>: phishing user data,
+          identity or other privacy sensitive attributes, destroying or
+          modifying NFC tags to cause further damage through fake identities
+          and attack vectors;
         </li>
         <li>
-          Malicious NFC tag creator: same as malicious web page owner, but
-          it has a possibility to create, delete or modify the NFC tags locally.
+          <strong>Malicious NFC tag creator</strong>: same as malicious web page
+          owner, but it has a possibility to create, delete or modify the NFC
+          tags locally.
           As a result can compromise integrity of user device, cause data
           injection, redirect to malicious web page, phishing user location,
-          causing side actions such as installing applications, trigger automated
-          dispatching or other actions.
+          causing side actions such as installing applications, trigger
+          automated dispatching or other actions.
         </li>
         <li>
-          Malicious MitM user: any MitM-style attack between a legitimate Web
-          NFC frontend and a user device using Web NFC interfaces. Also includes
-          attempts to interact with a legitimate web page exposing Web NFC
-          frontend by presenting modified or replayed NDEF records.
+          <strong>Malicious MitM user</strong>: any MitM (man in the middle)
+          style attack between Web NFC implementation and an <a>NFC adapter</a>
+          in a user device. A
+          Also includes attempts to interact with a web site using Web NFC
+          by presenting modified or replayed NDEF records.
         </li>
       </ul>
     </p>
@@ -4270,8 +4274,8 @@ TODO delete -->
         <dd>
           Malicious web page collects user data, identity or other privacy
           sensitive attributes (such as location) without user consent and
-          exposes it to third parties (writing it to NFC tags, sending to other
-          web NFC providers, etc.)
+          exposes it to third parties (writing it to NFC tags, pushing to NFC
+          peers).
         </dd>
         <dt><strong>Affected assets</strong></dt>
         <dd>
@@ -4304,8 +4308,8 @@ TODO delete -->
         <dd>
           An NFC tag is being modified without user consent.
           This might enable further attacks using a malicious tag
-          or can be a Denial of Service attack to make a tag
-          unusable by other users.
+          or can be a Denial of Service attack to make one or more tags
+          unusable.
         </dd>
         <dt><strong>Affected assets</strong></dt>
         <dd>
@@ -4313,7 +4317,7 @@ TODO delete -->
         </dd>
         <dt><strong>Actors</strong></dt>
         <dd>
-          Malicious web page creator, malicious MitM user.
+          Malicious web page creator, malicious MitM (man in the middle) user.
         </dd>
         <dt><strong>Mitigation, comments</strong></dt>
         <dd>
@@ -4323,6 +4327,57 @@ TODO delete -->
           Or, allow overwriting since tags not meant to be written can be
           protected by making them read only.
           Use <a>NDEF signature</a> to detect a modification of NFC tags.
+        </dd>
+      </dl>
+    </section>
+
+    <section> <h4>NDEF record modification in-transit</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          <a>NDEF record</a>s transferred between Web NFC and the
+          <a>NFC adapter</a> and user device are modified to cause various
+          MitM attacks or Denial of Service.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          <a>NDEF record</a>s in-transfer.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious MitM user.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          Use <a>NDEF signature</a>s to protect the NFC tag payload
+          and metadata. Additionally, harden the platform stack and
+          communication between the web NFC frontend and backend.
+          This thhreat is out of scope for Web NFC implementations.
+        </dd>
+      </dl>
+    </section>
+
+    <section> <h4>NDEF record payload disclosure</h4>
+      <dl>
+        <dt><strong>Threat description</strong></dt>
+        <dd>
+          Confidential payload of <a>NDEF record</a> in-storage (stored
+          on a NFC tag) or in-transfer between Web NFC and the
+          <a>NFC adapter</a> are read by unauthorized parties.
+        </dd>
+        <dt><strong>Affected assets</strong></dt>
+        <dd>
+          Confidential NDEF message payload in-transfer and in-storage.
+        </dd>
+        <dt><strong>Actors</strong></dt>
+        <dd>
+          Malicious MitM user, malicious web page creator.
+        </dd>
+        <dt><strong>Mitigation, comments</strong></dt>
+        <dd>
+          To ensure confidentiality, use payload encryption and secure
+          communication for data exchange, authentication and authorization
+          between Web NFC and <a>NFC adapter</a>s.
         </dd>
       </dl>
     </section>
@@ -4339,7 +4394,7 @@ TODO delete -->
         </dd>
         <dt><strong>Affected assets</strong></dt>
         <dd>
-          Integrity of user device, all other web NFC assets.
+          Integrity of user device, all other Web NFC assets.
         </dd>
         <dt><strong>Actors</strong></dt>
         <dd>
@@ -4362,60 +4417,7 @@ TODO delete -->
         </dd>
       </dl>
     </section>
-
-    <section> <h4>NDEF record modification in-transit</h4>
-      <dl>
-        <dt><strong>Threat description</strong></dt>
-        <dd>
-          <a>NDEF record</a>s transferred between the web NFC frontend/backend
-          and user device are modified to cause various MitM attacks or
-          Denial of Service.
-        </dd>
-        <dt><strong>Affected assets</strong></dt>
-        <dd>
-          NDEF message records, including payload and associated metadata
-          in-transfer.
-        </dd>
-        <dt><strong>Actors</strong></dt>
-        <dd>
-          Malicious MitM user.
-        </dd>
-        <dt><strong>Mitigation, comments</strong></dt>
-        <dd>
-          Use <a>NDEF signature</a>s to protect the NFC tag payload
-          and metadata. Additionally, harden the platform stack and
-          communication between the web NFC frontend and backend.
-        </dd>
-      </dl>
-    </section>
-
-    <section> <h4>NDEF record payload disclosure</h4>
-      <dl>
-        <dt><strong>Threat description</strong></dt>
-        <dd>
-          Confidential payload of <a>NDEF record</a> in-storage (stored
-          on a NFC tag) or in-transfer between Web NFC and the
-          <a>NFC adapter</a> are read by unauthorized parties.
-        </dd>
-        <dt><strong>Affected assets</strong></dt>
-        <dd>
-          Confidential NDEF message payload
-          in-transfer and in-storage.
-        </dd>
-        <dt><strong>Actors</strong></dt>
-        <dd>
-          Malicious MitM user, malicious web page creator.
-        </dd>
-        <dt><strong>Mitigation, comments</strong></dt>
-        <dd>
-          Use encryption for the payload and secure communication
-          protocols for data exchange, authentication and authorization
-          mechanisms between the web NFC page and NFC tag.
-        </dd>
-      </dl>
-    </section>
   </section>
-
 
   <section class="informative"> <h2>Security mechanisms</h2>
     <p>

--- a/index.html
+++ b/index.html
@@ -215,45 +215,6 @@
     The Augmented Backus-Naur Form (ABNF) notation used is specified in
     [[RFC5234]].
   </p>
-
-  <section> <h3>Security related terms</h3>
-  <p>
-    The term <dfn>expressed permission</dfn> refers to an act by the user, e.g.
-    via user interface or setting or host device platform features, using which
-    the user approves the permission of a <a>browsing context</a> to access the
-    given functionality.
-  </p>
-  <p>
-    The term <dfn data-lt="asked for forgiveness">ask for forgiveness</dfn> refers to some
-    form of unobtrusive notification that informs the user of an operation
-    while it is running.
-    UAs SHOULD provide the user with means to ignore similar future
-    operations from the same <a>origin</a> and advertise this to the user.
-  </p>
-  <p>
-    The term <dfn>prearranged trust relationship</dfn> means that the
-    UA has already established a trust relationship for a
-    certain operation using a platform specific mechanism, so that an
-    <a>expressed permission</a> from the user is not any more needed.
-    See also this
-    <a href="http://w3c.github.io/web-nfc/security-privacy.html#prearranged-trust-relationship">
-    section</a> in the Security and Privacy document.
-  </p>
-  <p>
-    The term <dfn>obtain permission</dfn> for a certain operation indicates
-    that the UA has either obtained <a>expressed permission</a>, or
-    <a>asked for forgiveness</a>, or ensured a
-    <a>prearranged trust relationship</a> exists.
-  </p>
-  <p>
-    The
-    <a href="https://www.w3.org/TR/permissions/#dictdef-permissiondescriptor">
-    <dfn>Web NFC permission name</dfn></a> is
-    <a href="https://github.com/w3c/permissions/issues/47">defined</a> as
-    "`nfc`".
-  </p>
-  </section>
-  <section> <h3>NFC specific terms</h3>
   <p>
     <b>NFC</b> stands for Near Field Communications, a short-range wireless
     technology operating at 13.56 MHz which enables communication between
@@ -303,7 +264,6 @@
     an <a>NFC tag</a> or an <a>NFC peer</a>. In the current API it is synonym
     to <a>NDEF message</a>.
   </p>
-  </section>
 </section> <!-- Terminology -->
 
 
@@ -4116,6 +4076,15 @@
 <!-- - - - - - - - - - - - - Security and Privacy - - - - - - - - - - - - - -->
 <section> <h2 id="security">Security and Privacy</h2>
   <p>
+    NFC technology involves multiple levels of security. Payments done with NFC
+    are considered to be at least as secure as with payment cards at hardware
+    level, but the whole software stack needs to be security hardened.
+    However, data transfers involve more threats. In order to mitigate these,
+    the NFC Forum introduced [[NDEF-SIGNATURE]].
+  </p>
+
+  <!--
+  <p>
     The trust model, attacker model, threat model and possible mitigation
     proposals for Web NFC are presented in the
     <a href="http://w3c.github.io/web-nfc/security-privacy.html">
@@ -4123,84 +4092,309 @@
     security and privacy model through normative requirements to
     implementations.
   </p>
+  -->
 
   <section> <h3>Chain of trust</h3>
-  <p>
-    Web pages using Web NFC are not trusted.
-    This means that the user needs to be aware of exactly what a web page is
-    intending to do with NFC at any given moment. Implementations need to
-    make sure that when the user authorizes a method of this API, then only that
-    action is run, without side effects, and exactly in the context and the
-    number of times the user allows the execution of NFC related operations,
-    according to the algorithmic steps detailed in this specification.
-  </p>
-  <p>
-    The integrity of <a>NFC content</a> SHOULD NOT be trusted when
-    used for implementing security policies, for instance the authenticity of
-    <a>record identifier</a>, unless a <a>prearranged trust relationship</a> exists.
-  </p>
-  <p>
-    Security considerations for media types in general are discussed in
-    [[RFC2048]] and [[RFC2046]].
-  </p>
+    <p>
+      Web pages using Web NFC are not trusted.
+      This means that the user needs to be aware of exactly what a web page is
+      intending to do with NFC at any given moment. Implementations need to
+      make sure that when the user authorizes a method of this API, then only
+      that action is run, without side effects, and exactly in the context and
+      the number of times the user allows the execution of NFC related
+      operations, according to the algorithmic steps detailed in this
+      specification.
+    </p>
+    <p>
+      The integrity of <a>NFC content</a> SHOULD NOT be trusted by web pages
+      unless it is encrypted by applications, or a
+      <a>prearranged trust relationship</a> exists.
+    </p>
+    <p>
+      Security considerations for media types in general are discussed in
+      [[RFC2048]] and [[RFC2046]].
+    </p>
   </section>
 
-  <section> <h3>Threats</h3>
-  <p>
-    The main threats are summarized in the
-    <a href="http://w3c.github.io/web-nfc/security-privacy.html#threats-and-possible-solutions">
-    Security and Privacy</a> document.
-  </p>
-  <div>
-    In this specification the following threats are handled with the highest
-    priority:
-    <ul>
-      <li>
-        User data privacy: involuntary sharing of user data (such as location,
-        contacts, personal data, etc) from an NFC-capable device such as a
-        phone, tablet, or PC.
-      </li>
-      <li>
-        Protecting existing <a>NFC tag</a>s from being overwritten by malicious
-        web pages.
-      </li>
-    </ul>
-  </div>
+  <section class="informative"> <h2>Attacker model</h2>
+    <p>
+      The following attacker patterns have been considered:
+      <ul>
+        <li>
+          malicious web page: phishing user data or location, destroying tags,
+          modifying an NFC tag to cause indirect damage through fake identities
+          and attack vectors;
+        </li>
+        <li>
+          malicious tag: data injection, redirect to malicious web page,
+          phishing user location, causing side actions such as installing
+          applications, trigger automated dispatching or other actions.
+        </li>
+      </ul>
+    </p>
   </section>
 
-  <section> <h3>Permissions and user prompts</h3>
-  <p>
-    This specification attempts to minimize user prompting and uses implicit
-    security policies to address the
-    <a href="http://w3c.github.io/web-nfc/security-privacy.html#threats-and-possible-solutions">
-    threats</a>.
-    However, this specification does not describe, nor does it
-    mandate specific user prompting policies. The term <a>obtain permission</a>
-    is used for acquiring trust for a given operation.
-  </p>
-  <p class="note">
-    The [[[PERMISSIONS]]] API is suggested to be used by
-    UAs for implementing NFC related [[[PERMISSIONS]]] in order to minimize
-    the need for user prompting.
-  </p>
-  <p>
-    All <a>expressed permission</a>s that are preserved beyond the current
-    browsing session MUST be revocable.
-  </p>
+  <section class="informative"> <h3>Threats</h3>
+    <div>
+      In this specification the following threats are handled with the highest
+      priority:
+      <ul>
+        <li>
+          User data privacy: involuntary sharing of user data (such as location,
+          contacts, personal data, etc) from an NFC-capable device such as a
+          phone, tablet, or PC.
+        </li>
+        <li>
+          Protecting existing <a>NFC tag</a>s from being overwritten by malicious
+          web pages.
+        </li>
+      </ul>
+    </div>
+    <p>
+      More examples for potential threats with Web NFC are given below.
+    </p>
+    <table class="simple" border="1">
+      <tr>
+        <th><strong>Threat</strong></th>
+        <th><strong>Comments, possible mitigation</strong></th>
+      </tr>
+      <tr>
+        <td>
+          Web page using the Web NFC API collects user data without the
+          consent of the user.
+        </td>
+        <td>
+          The user SHOULD be able to be aware of what data can be shared using
+          NFC from the given web page.
+          Use permissions and user prompts for accessing personal data,
+          minimize user data exposed to NFC.
+        </td>
+      </tr>
+      <tr>
+        <td>Malicious web page overwrites tags without user consent.</td>
+        <td>
+          Make sure the write is additive to previous content.
+          Or, require permission and user prompt needed for writing tags.
+          Or, control what tags can be written by a given web page, for instance
+          a web page can write only a tag which can be connected to its origin.
+          Or, allow overwriting since tags not meant to be written can be
+          protected by making them read only.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Malicious web page writes sensitive user data to tags and peer
+          devices.
+        </td>
+        <td>
+          The user should be able to be aware of what data can be shared using
+          NFC from the given web page.
+          Use permission/user prompt for writing tags and peers.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Malicious tag may be involuntarily or voluntarily read by devices
+          and the data read may constitute an attack vector on the user agent.
+        </td>
+        <td>
+          This is a generic problem with all existing NFC tags.
+          The data is considered application specific.
+          Implementations need security hardening.
+          Involuntary touch is low probability due to short range and critical
+          angle for reading.
+          It’s easier to attack elsewhere (e.g. WiFi and Bluetooth).
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Malicious smart poster tag attempts triggering an action on the
+          device which may be a threat.
+        </td>
+        <td>
+          Support for smart posters is not among the main use cases of Web
+          NFC; if and when supported, no automatic actions should be allowed,
+          the user must be made aware and given the ability to control what is
+          happening during the NFC communication.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          Malicious Web NFC tag could send an arbitrary payload to a website
+          via a user’s device, along with a user’s existing web credentials.
+          The webapp and server would need to treat that payload as completely
+          untrusted.
+        </td>
+        <td>
+          Suggest rules for handling payload safely, provide best-practice
+          methods for doing so, provide a sanitization/validation function.
+          Payload MAY be even cryptographically signed before writing it to a
+          tag so the contents could later be verified.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          A Web NFC tag could be used for leaking the user’s physical location,
+          <ul>
+            <li>
+              if the reading triggers a user’s device to navigate to a website
+              that can identify the tag and knows the tag's physical location.
+            </li>
+            <li>
+              by sending <a>NFC tag</a>s, either by directly sharing the user
+              location (when the <a>browsing context</a> has access to that),
+              or by sending information that can be used for inferring the
+              location of the user.
+            </li>
+          </ul>
+        </td>
+        <td>
+          A Web NFC tag SHOULD NOT ever trigger a user’s device to navigate
+          to a website without asking permission, unless the site has been in
+          the foreground or has been brought to the foreground and has been
+          granted permission. User agents SHOULD take into account the
+          security and privacy measures listed in the
+          <a href="http://dev.w3.org/geo/api/spec-source.html#security">
+          Geolocation API</a>.
+        </td>
+      </tr>
+    </table>
   </section>
 
-  <section class="informative"> <h3>Security policies</h3>
+  <section class="informative"> <h2>Security mechanisms</h2>
+    <p>
+      In order to support security policies concerning Web NFC, the following
+      mechanisms are recommended for the implementations.
+    </p>
+    <section> <h3><dfn>Obtain permission</dfn></h3>
+      Implementations SHOULD use one or more of the following mechanisms for
+      <dfn>obtaining permission</dfn>.
+      <ul>
+        <li>
+          A mechanism for obtaining <a>expressed permission</a> of the user.
+        </li>
+        <li>
+          A mechanism for <a>ask for forgiveness</a> policies.
+        </li>
+        <li>
+          A mechanism for <a>prearranged trust relationship</a>.
+        </li>
+      </ul>
+      <section> <h4><dfn>Expressed permission</dfn></h4>
+        <p>
+          Denotes an explicit permission given by the user.
+          The [[[PERMISSIONS]]] API is suggested to be used by
+          UAs for implementing NFC related permissions in order to minimize
+          the need for user prompting.
+        </p>
+        <p>
+          The
+          <a href="https://www.w3.org/TR/permissions/#dictdef-permissiondescriptor">
+          <dfn>Web NFC permission name</dfn></a> is
+          <a href="https://github.com/w3c/permissions/issues/47">defined</a> as
+          "`nfc`".
+        </p>
+      </section>
+      <section> <h4><dfn>Ask for forgiveness</dfn></h4>
+        <p>
+          Denotes an unobtrusive way to notify the user about an ongoing operation
+          with a possible action to cancel or undo the operation, and to
+          handle future occurences of the same operation by the same action.
+        </p>
+      </section>
+      <section> <h4><dfn>Prearranged trust relationship</dfn></h4>
+        <div>
+          A prearranged trust relationship means the UA has already
+          established a trust relationship for a certain operation using a
+          platform specific mechanism, so that an <a>expressed permission</a>
+          from the user is not any more needed. A few examples are given below.
+          <ul>
+            <li>
+              Web apps installed from a store, or web pages installed to home
+              screen (with [[appmanifest]]) MAY be considered trusted by the user
+              agent. In this case the trust concerns the web page and allowed
+              NFC functionality, but does not necessarily also concern the
+              data exchanged through NFC.
+            </li>
+            <li>
+              For trusting the integrity of the data exchanged via NFC, user
+              agents MAY use encrypted <a>NFC content</a> with key management
+              based on Public Key Infrastructure. Key management is out of the scope of Web NFC.
+              <p class="note">
+                This is different from application level end to end encryption.
+                Key management is then in application domain.
+              </p>
+            </li>
+            <li>
+              User agents MAY consider using <a>NDEF signature</a> records for
+              <a>NFC content</a> integrity. When <a>NDEF record</a>s are signed
+              with a site certificate, then that is considered
+              <a>prearranged trust relationship</a> and browser origin policy
+              MAY be applied to relax the security policies in this document,
+              in the case when the user agent wants to minimize or eliminate
+              user prompts involved in obtaining permissions.
+              The signing tools and Public Key Infrastructure for key management
+              are out of scope of Web NFC.
+            </li>
+          </ul>
+        </div>
+      </section>
+    </section>
+
+    <!--
+    <section> <h3>Store site URL as record identifier when writing data</h3>
+      <p>
+        When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
+        <a data-cite="dom#concept-host-serializer">serialized</a>,
+        of the <a>current settings object</a> MAY be stored as the <a>record
+        identifier</a> in each top-level <a>NDEF Record</a>. This does not make
+        the payload trusted.
+      </p>
+    </section>
+    <section> <h3>Include URI records with registrable domain</h3>
+      <p>
+        When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
+        <a data-cite="dom#concept-host-serializer">serialized</a>,
+        of the <a>current settings object</a> MAY be stored as a signed
+        <a>URI record</a>. This does not make other records trusted.
+      </p>
+    </section>
+    -->
+
+    <section> <h3>Sign NDEF records</h3>
+      <p>
+        When pushing an <a>NDEF message</a>, one, more, or all records MAY be
+        signed using <a>NDEF signature</a>.
+      </p>
+      <p>
+        In order to build a trust chain, a Public Key Infrastructure is also
+        needed for key mananegent.
+      </p>
+    </section>
+
+    <section> <h3>Content identification</h3>
+      <p>
+        Implementations or applications MAY use an identification mechanism for telling apart “Web NFC content" from generic NFC content. Also, a
+        mechanism for conveying implementation specific metadata which is not exposed to applications MAY be implemented.
+      </p>
+    </section>
+
+  </section>
+
+  <section> <h3>Security policies</h3>
     <p>
       This section summarizes the security policies which are specified as
       normative requirements in the respective algorithms of this
       specification.
     </p>
+
     <section> <h4>Secure Context</h4>
       <p>
         Only <a>secure contexts</a> are allowed to access <a>NFC content</a>.
         Browsers may ignore this rule for development purposes only.
       </p>
     </section>
+
     <section> <h4>Visible document</h4>
       <p>
         Web NFC functionality is allowed only for the {{Document}} of the
@@ -4214,24 +4408,26 @@
         must be <a id="#nfc-suspended">suspended</a>.
       </p>
     </section>
+
     <section> <h4>Permissions controls</h4>
       <p>
-        Making an <a>NFC tag</a> read-only must <a>obtain permission</a>, or
+        Making an <a>NFC tag</a> read-only MUST <a>obtain permission</a>, or
         otherwise fail.
       </p>
       <p>
-        Setting up listeners for reading <a>NFC content</a> should
+        Setting up listeners for reading <a>NFC content</a> SHOULD
         <a>obtain permission</a>.
       </p>
       <p>
-        The process of reading an <a>NDEF message</a> does not need to
+        Pushing <a>NFC content</a> to an <a>NFC peer</a> SHOULD
         <a>obtain permission</a>.
-      </p>
-      <p>
-        Pushing <a>NFC content</a> to an <a>NFC peer</a> does not need to
-        <a>obtain permission</a>, but the other rules in this section apply.
         See the [[[#writing-or-pushing-content]]] section.
       </p>
+      <p>
+        All <a>expressed permission</a>s that are preserved beyond the current
+        browsing session MUST be revocable.
+      </p>
+      <!--
       <p>
         Pushing an <a>NDEF message</a> to an <a>NFC tag</a> does not need to
         <a>obtain permission</a>, if the existing <a>NDEF message</a> only
@@ -4242,33 +4438,49 @@
         <a>NFC content</a> which overwrites existing information.
         See also the [[[#writing-or-pushing-content]]] section.
       </p>
+      -->
       <p>
         Since all local content that a web page has access to can be shared with
         NFC, the user needs to be clearly aware about the permissions granted
         to the web page using Web NFC.
       </p>
     </section>
-    <section> <h4>Store site URL as record identifier when writing data</h4>
-      <p>
-        When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
-        <a data-cite="dom#concept-host-serializer">serialized</a>,
-        of the <a>current settings object</a> must be stored as the <a>record
-        identifier</a> in each top-level <a>NDEF Record</a>.
-      </p>
-    </section>
     <section> <h4>Warn risk of physical location leak</h4>
       <p>
         When listening for and pushing <a>NFC content</a>,
-        the UA may warn the user that the given <a>origin</a> may be able to
+        the UA MAY warn the user that the given <a>origin</a> may be able to
         infer physical location.
       </p>
     </section>
     <section> <h4>Restrict automatic handling</h4>
       <p>
-        The payload data on <a>NFC content</a> is untrusted, and must not be used
-        by the UA to do automatic handling such as opening a web page
-        with a URL found in an <a>NFC tag</a>, unless the user approves that.
+        When the payload data on <a>NFC content</a> is untrusted, and MUST NOT
+        be used by the UA to do automatic handling of the content, such as
+        opening a web page with a URL found in an <a>NFC tag</a>, or installing
+        an application, or other actions, unless the user approves that.
       </p>
+    </section>
+    <section> <h4>Policies for signing <a>NFC content</a></h4>
+      <div>
+        For tags signed with <a>NDEF signature</a> version 1.0 ([[NFC-SECURITY]]),
+        the signature is applied only to the <a>TYPE field</a>, <a>ID field</a>
+        and <a>PAYLOAD field</a>, leaving out the first byte of the NDEF header,
+        allowing surface to attacks. Version 2.0 of [[NFC-SECURITY]] included
+        tag hardware attributes in the signature and allowed for shorter
+        certificates.
+        Therefore the following additional policies apply to
+        <a>NDEF signature</a>:
+        <ul>
+          <li>
+            A <a>smart poster</a> can be trusted only if signed by using
+            a single <a>NDEF signature</a> record by the same issuer.
+          </li>
+          <li>
+            An <a>NDEF message</a> can be trusted only if signed by
+            a single <a>NDEF signature</a> record by the same issuer.
+          </li>
+        </ul>
+      </div>
     </section>
       <!--p>
         For Bluetooth and WiFi handover (supported in later versions),
@@ -4276,6 +4488,7 @@
         able to properly understand what they are granting.
       </p-->
   </section> <!-- Policies -->
+
 </section> <!-- Security and Privacy  -->
 
 <section id="idl-index" class="appendix">
@@ -4294,7 +4507,8 @@
     Special thanks to Luc Yriarte and Samuel Ortiz for their initial
     <a href="https://github.com/w3c/nfc">work</a>
     on exposing NFC to the web platform, and for their support for the current
-    approach.
+    approach. Also, special thanks to Elena Reshetova for the contributions to
+    the Security and Privacy section.
   </p>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -2161,6 +2161,51 @@
     according to the algorithmic steps described in this specification.
   </section>
 
+  <section><h3>Obtaining permission</h3>
+    <p>
+      The
+      <a href="https://www.w3.org/TR/permissions/#dictdef-permissiondescriptor">
+      <dfn>Web NFC permission name</dfn></a> is
+      <a href="https://github.com/w3c/permissions/issues/47">defined</a> as
+      "`nfc`".
+    </p>
+    <div>
+      To <dfn>obtain permission</dfn>, run these steps:
+      <ol class=algorithm>
+        <li>
+          Run the
+          <a>query a permission</a> steps for the
+          <a>Web NFC permission name</a> until completion.
+          <ol>
+            <li>
+              If it resolved with {{PermissionState["granted"]}}
+              (i.e. permission has been granted to the <a>origin</a> and
+              <a>global object</a> using the [[[PERMISSIONS]]] API),
+              return `true`.
+            </li>
+            <li>
+              Otherwise, if it resolved with {{PermissionState["prompt"]}}, then optionally
+              <a data-lt="request permission to use">request permission</a>
+              from the user for the <a>Web NFC permission name</a>.
+              If that is granted, return `true`.
+              <p class="issue">
+                The <a data-lt="request permission to use">request permission</a>
+                steps are not yet clearly defined.
+                At this point the UA asks the user about the policy to be used
+                with the <a>Web NFC permission name</a> for the given
+                <a>origin</a> and <a>global object</a>, if the user grants permission,
+                return `true`.
+              </p>
+            </li>
+          </ol>
+        </li>
+        <li>
+          Return `false`.
+        </li>
+      </ol>
+    </div>
+  </section>
+
   <section><h3>Handling visibility change</h3>
     <p>
       When the user agent determines that the
@@ -2555,7 +2600,7 @@
                     If |idHost| is `null`, or different than the
                     <a data-cite="url#concept-host-serializer">
                     serialized host</a> of the <a>current settings object</a>'s
-                    origin, and the <a>obtain push permission</a> steps return
+                    origin, and the <a>obtain permission</a> steps return
                     `false`, then reject |p| with {{"NotAllowedError"}}
                     {{DOMException}} and abort these steps.
                   </li>
@@ -2594,44 +2639,6 @@
                 When the transfer has completed, resolve |p|.
               </li>
             </ol>
-          </li>
-        </ol>
-      </div>
-    </section>
-
-    <section><h3>Obtaining push permission</h3>
-      <div>
-        To <dfn>obtain push permission</dfn>, run these steps:
-        <ol class=algorithm>
-          <li>
-            Run the
-            <a>query a permission</a> steps for the
-            <a>Web NFC permission name</a> until completion.
-            <ol>
-              <li>
-                If it resolved with {{PermissionState["granted"]}}
-                (i.e. an <a>expressed permission</a> has been granted
-                to the <a>origin</a> and <a>global object</a> using
-                the [[[PERMISSIONS]]] API), return `true`.
-              </li>
-              <li>
-                Otherwise, if it resolved with {{PermissionState["prompt"]}}, then optionally
-                <a data-lt="request permission to use">request permission</a>
-                from the user for the <a>Web NFC permission name</a>.
-                If that is granted, return `true`.
-                <p class="issue">
-                  The <a data-lt="request permission to use">request permission</a>
-                  steps are not yet clearly defined.
-                  At this point the UA asks the user about the policy to be used
-                  with the <a>Web NFC permission name</a> for the given
-                  <a>origin</a> and <a>global object</a>, if the user grants permission,
-                  return `true`.
-                </p>
-              </li>
-            </ol>
-          </li>
-          <li>
-            Return `false`.
           </li>
         </ol>
       </div>
@@ -3447,7 +3454,7 @@
             Run the following steps <a>in parallel</a>:
             <ol>
               <li>
-                If the <a>obtain reading permission</a> steps return
+                If the <a>obtain permission</a> steps return
                 `false`, then reject |p| with a
                 {{"NotAllowedError"}} {{DOMException}}
                 and return |p|.
@@ -3483,37 +3490,6 @@
                 <a>NFC reading algorithm</a>.
               </li>
             </ol>
-          </li>
-        </ol>
-      </div>
-      <div>
-        To <dfn>obtain reading permission</dfn>, run these steps:
-        <ol>
-          <li>
-            Otherwise, if the user has earlier denied permission for the calling
-            <a>origin</a> for all future calls of
-            <a data-link-for="NDEFReader">scan()</a>
-            as well, then return `false`.
-          </li>
-          <li>
-            Otherwise, UAs SHOULD <a>ask for forgiveness</a> with relevant
-            information displayed to the user.
-            <p class="note">
-              The <a>ask for forgiveness</a> interaction
-              might show choices like "block now" or "block forever", etc.
-              If the user has chosen to "block forever" the given
-              <a>origin</a>, it is the responsibility of the UA to remember
-              these user choices for each <a>origin</a>, regardless of which
-              <a>NFC adapter</a> is used, and consult them on later invocations.
-            </p>
-            <p class="note">
-             In this step UAs are advised to notify users about
-             that reading <a>NFC content</a> may indirectly reveal the physical
-             location of the user.
-            </p>
-          </li>
-          <li>
-            Return `true`.
           </li>
         </ol>
       </div>
@@ -4079,13 +4055,17 @@
       specification.
     </p>
     <p>
+      Web NFC does not sign <a>NFC content</a>. Using <a>NDEF signature</a> and
+      key management is application domain.
+    </p>
+    <p>
       For trusting the <strong>confidentiality</strong> of the data exchanged
-      via NFC, user agents MAY use encrypted <a>NFC content</a>.
+      via NFC, applications may use encrypted <a>NFC content</a>.
     </p>
     <p>
       For trusting the <strong>integrity</strong> of the data exchanged via NFC,
-      user agents MAY use an <a>NDEF signature</a>, with key management based on
-      Public Key Infrastructure (PKI).
+      applications may use an <a>NDEF signature</a>, with key management based
+      on Public Key Infrastructure (PKI).
     </p>
     <p>
       Security considerations for MIME types in general are discussed in
@@ -4150,121 +4130,16 @@
         <li>
           <strong>Malicious MitM user</strong>: any MitM (man in the middle)
           style attack between Web NFC implementation and an <a>NFC adapter</a>
-          in a user device. A
-          Also includes attempts to interact with a web site using Web NFC
-          by presenting modified or replayed NDEF records.
+          in a user device, including attempts to interact with a web site using
+          Web NFC by presenting modified or replayed NDEF records.
         </li>
       </ul>
     </p>
   </section>
 
-<!-- TODO: this section is being rewritten and to be removed later
   <section class="informative"> <h3>Threats</h3>
     <p>
-      Potential threats for Web NFC are given below.
-    </p>
-    <table class="simple" border="1">
-      <tr>
-        <th><strong>Threat</strong></th>
-        <th><strong>Comments, possible mitigation</strong></th>
-      </tr>
-      <tr>
-        <td>
-          Web page using the Web NFC API collects user data without the
-          consent of the user.
-        </td>
-        <td>
-          The user SHOULD be able to be aware of what data can be shared using
-          NFC from the given web page.
-          Use permissions and user prompts for accessing personal data,
-          minimize user data exposed to NFC.
-        </td>
-      </tr>
-      <tr>
-        <td>Malicious web page overwrites tags without user consent.</td>
-        <td>
-          Make sure the write is additive to previous content.
-          Or, require permission and user prompt needed for writing tags.
-          Or, control what tags can be written by a given web page, for instance
-          a web page can write only a tag which can be connected to its origin.
-          Or, allow overwriting since tags not meant to be written can be
-          protected by making them read only.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Malicious web page writes sensitive user data to tags and peer
-          devices.
-        </td>
-        <td>
-          The user should be able to be aware of what data can be shared using
-          NFC from the given web page.
-          Use permission/user prompt for writing tags and peers.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Malicious tag may be involuntarily or voluntarily read by devices
-          and the data read may constitute an attack vector on the user agent.
-        </td>
-        <td>
-          This is a generic problem with all existing NFC tags.
-          The data is considered application specific.
-          Implementations need security hardening.
-          Involuntary touch is low probability due to short range and critical
-          angle for reading, and due to the focus requirements.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Malicious smart poster tag attempts triggering an action on the
-          device which may be a threat.
-        </td>
-        <td>
-          Support for smart posters is not among the main use cases of Web
-          NFC; if and when supported, no automatic actions should be allowed,
-          the user must be made aware and given the ability to control what is
-          happening during the NFC communication. For instance: opening content
-          from <a>smart poster</a>, automatic connection to (possibly malicious)
-          WiFi via <a>NFC handover</a>, etc.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          Malicious Web NFC tag payload read by a website may inflict cause
-          via a user’s device, along with a user’s existing web credentials.
-          The webapp and server would need to treat that payload as completely
-          untrusted.
-        </td>
-        <td>
-          Suggest rules for handling payload safely, provide best-practice
-          methods for doing so, provide a sanitization/validation function.
-          Payload MAY be even cryptographically signed before writing it to a
-          tag so the contents could later be verified.
-        </td>
-      </tr>
-      <tr>
-        <td>
-          A Web NFC tag could be used for leaking the user’s physical location,
-          if the reading triggers a user’s device to navigate to a website
-          that can identify the tag and knows the tag's physical location.
-        </td>
-        <td>
-          A NFC tag SHOULD NOT ever trigger a user’s device to navigate
-          to a website without asking permission, unless the site has been in
-          the foreground or has been brought to the foreground and has been
-          granted permission. User agents SHOULD take into account the
-          security and privacy measures listed in the
-          <a href="http://dev.w3.org/geo/api/spec-source.html#security">
-          Geolocation API</a>.
-        </td>
-      </tr>
-    </table>
-  </section>
-TODO delete -->
-
- <section class="informative"> <h3>Threats</h3>
-    <p>
+      An introduction to NFC security is found <a href="https://resources.infosecinstitute.com/near-field-communication-nfc-technology-vulnerabilities-and-principal-attack-schema/">here</a>.
       Potential threats for Web NFC are given below.
     </p>
 
@@ -4419,56 +4294,30 @@ TODO delete -->
     </section>
   </section>
 
-  <section class="informative"> <h2>Security mechanisms</h2>
+  <section class="informative"> <h2>Security mechanisms for implementations</h2>
     <p>
       In order to support security policies concerning Web NFC, the following
-      mechanisms are recommended for the implementations.
+      mechanisms are recommended for implementations.
     </p>
     <section> <h3><dfn>Obtaining permission</dfn></h3>
-      Implementations SHOULD use one or more of the following mechanisms to
-      <dfn>obtain permission</dfn>.
-      <ul>
-        <li>
-          A mechanism for obtaining <a>expressed permission</a> of the user.
-        </li>
-        <li>
-          A mechanism for <a>ask for forgiveness</a> policies.
-        </li>
-      </ul>
-      <section> <h4><dfn>Expressed permission</dfn></h4>
-        <p>
-          Denotes an explicit permission given by the user.
-          The [[[PERMISSIONS]]] API is suggested to be used by
-          UAs for implementing NFC related permissions in order to minimize
-          the need for user prompting.
-        </p>
-        <p>
-          The
-          <a href="https://www.w3.org/TR/permissions/#dictdef-permissiondescriptor">
-          <dfn>Web NFC permission name</dfn></a> is
-          <a href="https://github.com/w3c/permissions/issues/47">defined</a> as
-          "`nfc`".
-        </p>
-      </section>
-      <section> <h4><dfn>Ask for forgiveness</dfn></h4>
-        <p>
-          Denotes an unobtrusive way to notify the user about an ongoing operation
-          with a possible action to cancel or undo the operation, and to
-          handle future occurences of the same operation by the same action.
-        </p>
-      </section>
+      <p>
+        Implementations SHOULD use one or more of the following mechanisms to
+        <a>obtain permission</a>, for instance an explicit permission given
+        by the user. The [[[PERMISSIONS]]] API is suggested to be used by UAs
+        for implementing NFC related permissions.
+      </p>
     </section>
-
+  </section>
+  <section class="informative"> <h2>Security mechanisms for applications</h2>
+    <p>
+      The following mechanisms are recommended to be used by applications.
+    </p>
     <section> <h3>Encrypting <a>NFC content</a></h3>
       <p>
-        For trusting the confidentiality of the data exchanged via NFC, user agents
-        MAY use encrypted <a>NFC content</a> with key management based on
-        Public Key Infrastructure (PKI).
+        For trusting the confidentiality of the data exchanged via NFC,
+        applications may use encrypted <a>NFC content</a> with key management
+        based on Public Key Infrastructure (PKI).
         Key management is out of the scope of Web NFC.
-      </p>
-      <p class="note">
-        This is different from application level end to end encryption.
-        Key management is then in application domain.
       </p>
     </section>
 
@@ -4486,40 +4335,24 @@ TODO delete -->
         tag hardware attributes in the signature and allowed for shorter
         certificates.
       </p>
+      <p>
+        An <a>NDEF signature</a> covers the preceding records until another
+        <a>NDEF signature</a> or the beginning of the <a>NDEF message</a> is
+        reached.
+      </p>
+      <p>
+        In order to mitigate <a href="https://www.researchgate.net/publication/224227216_Security_Vulnerabilities_of_the_NDEF_Signature_Record_Type">
+        known vulnerabilities</a> of <a>NDEF signature</a>, it is recommended
+        that applications always sign a full <a>NDEF message</a> with a single
+        <a>NDEF signature</a>.
+      </p>
     </section>
 
-    <section> <h3>Content identification</h3>
-      <p>
-        Implementations or applications MAY use an identification mechanism for
-        telling apart “Web NFC content" from generic NFC content. Also, a
-        mechanism for conveying implementation specific metadata which is not
-        exposed to applications MAY be implemented.
-      </p>
-      <section> <h4>Store site URL as record identifier when writing data</h4>
-        <p>
-          When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
-          <a data-cite="dom#concept-host-serializer">serialized</a>,
-          of the <a>current settings object</a> MAY be stored as the <a>record
-          identifier</a> in each top-level <a>NDEF Record</a>.
-          This does not make the payload trusted.
-        </p>
-      </section>
-      <section> <h4>Include URI records with registrable domain</h4>
-        <p>
-          When pushing an <a>NDEF message</a>, the [= host/registrable domain =],
-          <a data-cite="dom#concept-host-serializer">serialized</a>,
-          of the <a>current settings object</a> MAY be stored as a signed
-          <a>URI record</a>. This does not make other records trusted.
-        </p>
-      </section>
-    </section>
   </section>
 
   <section> <h3>Security policies</h3>
     <p>
-      This section summarizes the security policies which are specified as
-      normative requirements in the respective algorithms of this
-      specification.
+      This section lists the normative security policies for implementations.
     </p>
 
     <section> <h4>Secure Context</h4>
@@ -4558,21 +4391,9 @@ TODO delete -->
         See the [[[#writing-or-pushing-content]]] section.
       </p>
       <p>
-        All <a>expressed permission</a>s that are preserved beyond the current
+        All permission that are preserved beyond the current
         browsing session MUST be revocable.
       </p>
-      <!--
-      <p>
-        Pushing an <a>NDEF message</a> to an <a>NFC tag</a> does not need to
-        <a>obtain permission</a>, if the existing <a>NDEF message</a> only
-        contains <a>NDEF record</a>s without <a>ID field</a>s, or with <a>
-        ID field</a>s matching the [=host/registrable domain=] of the
-        <a>current settings object</a>'s origin.
-        Otherwise the UA must <a>obtain permission</a> for pushing
-        <a>NFC content</a> which overwrites existing information.
-        See also the [[[#writing-or-pushing-content]]] section.
-      </p>
-      -->
     </section>
 
     <section> <h4>Warn about risk of physical location leak</h4>
@@ -4594,8 +4415,7 @@ TODO delete -->
 
     <section> <h4>Signing <a>NFC content</a></h4>
       <div>
-        In this version of the specification the following policies are
-        recommended:
+        The following policies are recommended to be implemented by applications.
         <ul>
           <li>
             A <a>smart poster</a> MAY be trusted only if signed by using

--- a/index.html
+++ b/index.html
@@ -892,7 +892,7 @@
           Writing to a non-formatted <a>NFC tag</a>.
         </li>
         <li>
-          Writing to an empty <a>NFC tag</a>.
+          Writing to an empty, but formatted <a>NFC tag</a>.
         </li>
         <li>
           Writing to an <a>NFC tag</a> which already contains a
@@ -4091,11 +4091,12 @@
           <strong>User identity or other privacy sensitive attributes</strong>
           that can be directly or indirectly determined by using Web NFC, by the
           <a>NFC content</a> creator by a web site using Web NFC.
-          This data could be used directly or leaked forward to third parties. Examples are user location, device identifiers and user identifiers.
+          This data could be used directly or leaked forward to third parties.
+          Examples are user location, device identifiers and user identifiers.
         </li>
         <li>
           <strong>User data</strong> exposed to a web page using Web NFC.
-          While web page might collect user data using other means than
+          While a web page might collect user data using other means than
           Web NFC, it might embed this data into NDEF records and share via
           Web NFC.
         </li>
@@ -4128,7 +4129,7 @@
           automated dispatching or other actions.
         </li>
         <li>
-          <strong>Malicious MitM user</strong>: any MitM (man in the middle)
+          <strong>Malicious man-in-the-middle (MITM) user</strong>: any MITM
           style attack between Web NFC implementation and an <a>NFC adapter</a>
           in a user device, including attempts to interact with a web site using
           Web NFC by presenting modified or replayed NDEF records.
@@ -4192,7 +4193,7 @@
         </dd>
         <dt><strong>Actors</strong></dt>
         <dd>
-          Malicious web page creator, malicious MitM (man in the middle) user.
+          Malicious web page creator, malicious user.
         </dd>
         <dt><strong>Mitigation, comments</strong></dt>
         <dd>
@@ -4212,7 +4213,7 @@
         <dd>
           <a>NDEF record</a>s transferred between Web NFC and the
           <a>NFC adapter</a> and user device are modified to cause various
-          MitM attacks or Denial of Service.
+          man-in-the-middle attacks or denial-of-service (DoS) attacks.
           Also, <a>NDEF signature</a> records can be removed or
           replaced along with changed content.
         </dd>
@@ -4222,7 +4223,7 @@
         </dd>
         <dt><strong>Actors</strong></dt>
         <dd>
-          Malicious MitM user.
+          Malicious man-in-the-middle user.
         </dd>
         <dt><strong>Mitigation, comments</strong></dt>
         <dd>
@@ -4248,7 +4249,7 @@
         </dd>
         <dt><strong>Actors</strong></dt>
         <dd>
-          Malicious MitM user, malicious web page creator.
+          Malicious man-in-the-middle user, malicious web page creator.
         </dd>
         <dt><strong>Mitigation, comments</strong></dt>
         <dd>


### PR DESCRIPTION
Added attacker model, threats analysis etc from the Security and Privacy document, updated for the current API.

Commented out the sections dealing with relaxing permissions based on the ID field,
but added as mechanisms for content identification.

Signature records are not specified in this PR, only the general policies with them.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/web-nfc/pull/440.html" title="Last updated on Nov 21, 2019, 1:55 PM UTC (ce9c576)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/440/28024bb...zolkis:ce9c576.html" title="Last updated on Nov 21, 2019, 1:55 PM UTC (ce9c576)">Diff</a>