### PR TITLE
non-Mime record should have a null mediaType

### DIFF
--- a/index.html
+++ b/index.html
@@ -1914,35 +1914,35 @@
       <td>0</td>
       <td><i>unused</i></td>
       <td>"`empty`"</td>
-      <td>`undefined`</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`T`"</td>
       <td>"`text`"</td>
-      <td>`undefined`</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`U`"</td>
       <td>"`url`"</td>
-      <td>`undefined`</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`Sp`"</td>
       <td nowrap>"`smart-poster`"</td>
-      <td>`undefined`</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=Local type=] record*</td>
       <td>1</td>
       <td>[=local type name=]</td>
       <td>[=local type name=]</td>
-      <td>`undefined`</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=MIME type record=]</td>
@@ -1956,21 +1956,21 @@
       <td>3</td>
       <td>URL</td>
       <td>"`absolute-url`"</td>
-      <td>`undefined`</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td>[=External type record=]</a></td>
       <td>4</td>
       <td>[=external type name=]</td>
       <td>[=external type name=]</td>
-      <td>`undefined`</td>
+      <td>`null`</td>
     </tr>
     <tr>
       <td><a>Unknown record</a></td>
       <td>5</td>
       <td><i>unused</i></td>
       <td>"`unknown`"</td>
-      <td>`undefined`</td>
+      <td>`null`</td>
     </tr>
   </table>
   </section>
@@ -3711,7 +3711,7 @@
             remaining length of |bytes|, return |records|.
           </li>
           <li>
-            Let |ndef| be the notation for the current <a>NDEF record</a>
+            Let |ndef| be the notation for the current <a>NDEF record</a>.
           </li>
           <li>
             Let |header:byte| be the next byte of |bytes|.
@@ -3803,8 +3803,15 @@
         Set |record|'s encoding to `null`.
       </li>
       <li>
-        If |ndef|'s |typeNameField:number| is `0` (<a>empty record</a>), then set
-        |record|'s recordType to "`empty`".
+        If |ndef|'s |typeNameField:number| is `0` (<a>empty record</a>):
+        <ol>
+          <li>
+            Set |record|'s recordType to "`empty`".
+          </li>
+          <li>
+            Set |record|'s mediaType to `null`.
+          </li>
+        </ol>
       </li>
       <li>
         If |ndef|'s |typeNameField| is `1` ([=well-known type record=]):
@@ -3871,9 +3878,7 @@
         Set |record|'s recordType to "`text`".
       </li>
       <li>
-        Let |mimeType| be a <a>MIME type</a>
-        with type "`text`", subtype "`plain`" and parameters
-        equal to an empty ordered map.
+        Set |record|'s mediaType to `null`.
       </li>
       <li>
         If |ndefRecord|'s <a>PAYLOAD field</a> is not present, set
@@ -3961,6 +3966,9 @@
         Set |record|'s recordType to "`url`".
       </li>
       <li>
+        Set |record|'s mediaType to `null`.
+      </li>
+      <li>
         If |ndefRecord|'s <a>PAYLOAD field</a> is not present,
         set |record|.<a>[[\PayloadData]]</a> to `undefined` and return |record|.
       </li>
@@ -4000,6 +4008,9 @@
     <ol class=algorithm>
       <li>
         Set |record|'s recordType to "`smart-poster`".
+      </li>
+      <li>
+        Set |record|'s mediaType to `null`.
       </li>
       <li>
         If |ndefRecord|'s <a>PAYLOAD field</a> is not present, set |record|.<a>[[\PayloadData]]</a> to `undefined` and return |record|.
@@ -4054,6 +4065,9 @@
           Set |record|'s recordType to "`absolute-url`".
         </li>
         <li>
+          Set |record|'s mediaType to `null`.
+        </li>
+        <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of
           |ndefRecords|'s <a>TYPE field</a>.
         </li>
@@ -4076,6 +4090,9 @@
           Set |record|'s recordType to the value of |ndefRecord|'s <a>TYPE field</a>.
         </li>
         <li>
+          Set |record|'s mediaType to `null`.
+        </li>
+        <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of
           |ndefRecords|'s <a>PAYLOAD field</a> if that exists, or otherwise `undefined`.
         </li>
@@ -4096,6 +4113,9 @@
       <ol class=algorithm>
         <li>
           Set |record|'s recordType to "`unknown`".
+        </li>
+        <li>
+          Set |record|'s mediaType to `null`.
         </li>
         <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Honry/web-nfc/pull/441.html" title="Last updated on Nov 10, 2019, 12:25 PM UTC (edd1020)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/441/6b0cdb8...Honry:edd1020.html" title="Last updated on Nov 10, 2019, 12:25 PM UTC (edd1020)">Diff</a>