### PR TITLE
Fix problems in "Create NDEF message"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2706,8 +2706,10 @@
                   |recordType| set to "`text`" and |data| set to |message|.
                 </li>
                 <li>
-                  Set |message|'s records to a list of records that contain only
-                  |textRecord|.
+                  Let |records| be the list « |textRecord| ».
+                </li>
+                <li>
+                  Set |message|'s records to |records|.
                 </li>
               </ul>
               <dt>{{BufferSource}}</dt>
@@ -2718,8 +2720,10 @@
                     |mediaType| set to "`application/octet-stream`".
                   </li>
                   <li>
-                    Set |message|'s records to a list of records that contain only
-                    |mimeRecord|.
+                    Let |records| be the list « |mimeRecord| ».
+                  </li>
+                  <li>
+                    Set |message|'s records to |records|.
                   </li>
               </ul>
               <dt>{{NDEFMessageInit}}</dt>

--- a/index.html
+++ b/index.html
@@ -2703,7 +2703,7 @@
               <ul>
                 <li>
                   Let |textRecord| be an <a>NDEFrecord</a> initialized with its
-                  |recordType| set to "`text/plain`" and |data| set to |message|.
+                  |recordType| set to "`text`" and |data| set to |message|.
                 </li>
                 <li>
                   Set |message|'s records to a list of records that contain only
@@ -2826,7 +2826,7 @@
                 </dl>
               </li>
               <li>
-                If |record|'s |id| is not `null`:
+                If |record|'s |id| is not `undefined`:
                 <ul>
                   <li>
                     Set |identifier| to the result of invoking

--- a/index.html
+++ b/index.html
@@ -1530,7 +1530,7 @@
 
         readonly attribute USVString recordType;
         readonly attribute USVString? mediaType;
-        readonly attribute USVString id;
+        readonly attribute USVString? id;
         readonly attribute DataView? data;
 
         readonly attribute USVString? encoding;
@@ -2697,15 +2697,46 @@
           |message:NDEFMessageSource| run these steps:
         </p>
         <ol class=algorithm id="create-web-nfc-message">
-          <li>
-            If the |message:NDEFMessageSource| parameter is not of type defined
-            by the <a>NDEFMessageSource</a> union, throw a {{TypeError}} and
-            abort these steps.
-          </li>
-          <li>
-            If the |message:NDEFMessageSource| parameter is of
-            <a>NDEFMessageInit</a> type, and |message|'s records
-            [= list/is empty =], throw a {{TypeError}} and abort these steps.
+          <li>Switch on |message:NDEFMessageSource|'s type:
+            <dl>
+              <dt>{{DOMString}}</dt>
+              <ul>
+                <li>
+                  Let |textRecord| be an <a>NDEFrecord</a> initialized with its
+                  |recordType| set to "`text/plain`" and |data| set to |message|.
+                </li>
+                <li>
+                  Set |message|'s records to a list of records that contain only
+                  |textRecord|.
+                </li>
+              </ul>
+              <dt>{{BufferSource}}</dt>
+              <ul>
+                  <li>
+                    Let |mimeRecord| be an <a>NDEFrecord</a> initialized with its
+                    |recordType| set to "`mime`", |data| set to |message|, and
+                    |mediaType| set to "`application/octet-stream`".
+                  </li>
+                  <li>
+                    Set |message|'s records to a list of records that contain only
+                    |mimeRecord|.
+                  </li>
+              </ul>
+              <dt>{{NDEFMessageInit}}</dt>
+              <ul>
+                <li>
+                  If |message|'s records [= list/is empty =], throw a
+                  {{TypeError}} and abort these steps.
+                </li>
+              </ul>
+              <dt>unmatched type</dt>
+              <ul>
+                <li>
+                  [= exception/throw =] a {{TypeError}} and abort these steps.
+                </li>
+              </ul>
+            </dl>
+            </dl>
           </li>
           <li>
             Let |output| be the notation for the <a>NDEF message</a>
@@ -2795,8 +2826,7 @@
                 </dl>
               </li>
               <li>
-                If |message| is of type {{NDEFMessageInit}} and its
-                |id:string| is not `null`:
+                If |record|'s |id| is not `null`:
                 <ul>
                   <li>
                     Set |identifier| to the result of invoking


### PR DESCRIPTION
As raised by @leonhsl, this PR fixes issues in "Create NDEF message":
1. Handle `DOMString` and `BufferSource` to create an NDEFMessage.
2. Use NDEFRecord instead of NDEFMessage for `id`.

FIX #443


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/444.html" title="Last updated on Nov 19, 2019, 9:52 AM UTC (1bcd82b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/444/6b0cdb8...beaufortfrancois:1bcd82b.html" title="Last updated on Nov 19, 2019, 9:52 AM UTC (1bcd82b)">Diff</a>