### PR TITLE
Move user activation to obtain permission

### DIFF
--- a/index.html
+++ b/index.html
@@ -2441,11 +2441,6 @@
             {{DOMException}} and return |p|.
           </li>
           <li>
-            If the algorithm is not <a>triggered by user activation</a>, then
-            reject |p| with a {{"NotAllowedError"}} {{DOMException}} and
-            return |p|.
-          </li>
-          <li>
             Let |signal:AbortSignal| be the |options|’ dictionary member
             of the same name if present, or `null` otherwise.
           </li>
@@ -3297,11 +3292,6 @@
             (e.g. a user preference), then reject |p| with a
             {{"NotReadableError"}} {{DOMException}}
             and return |p|.
-          </li>
-          <li>
-            If the algorithm is not <a>triggered by user activation</a>, then
-            reject |p| with a {{"NotAllowedError"}} {{DOMException}} and
-            return |p|.
           </li>
           <li>
             If |reader|.<a>[[\Signal]]</a>'s [= AbortSignal/aborted flag =] is


### PR DESCRIPTION
This PR aims to move the "triggered by user activation" bit from scan and push operations to the "obtain permission" section. 

https://github.com/w3c/permissions/issues/194 tracks the progress of updating the permissions API algorithm to state that user activation is required for showing a permission prompt if the permission state is "prompt".
@mustaqahmed what's the current status?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/449.html" title="Last updated on Nov 26, 2019, 12:42 PM UTC (3632fa3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/449/61d614b...beaufortfrancois:3632fa3.html" title="Last updated on Nov 26, 2019, 12:42 PM UTC (3632fa3)">Diff</a>