### PR TITLE
Do not use 'any' to define NDEFRecordInit#data

### DIFF
--- a/index.html
+++ b/index.html
@@ -1492,6 +1492,8 @@
       <a>NDEFRecord</a> interface:
     </p>
     <pre class="idl">
+      typedef (DOMString or BufferSource or NDEFMessageInit) NDEFRecordDataSource;
+
       [Exposed=Window]
       interface NDEFRecord {
         constructor(NDEFRecordInit recordInit);
@@ -1515,7 +1517,7 @@
         USVString encoding;
         USVString lang;
 
-        any data;
+        NDEFRecordDataSource data;
       };
     </pre>
     <p>
@@ -1767,7 +1769,7 @@
     <tr>
       <td nowrap><dfn>"`smart-poster`"</dfn></td>
       <td><i>unused</i></td>
-      <td>{{NDEFMessage}}</td>
+      <td>{{NDEFMessageInit}}</td>
       <td>[=Well-known type record=]</td>
       <td>1</td>
       <td>"`Sp`"</td>

--- a/index.html
+++ b/index.html
@@ -1805,7 +1805,7 @@
       <td><i>unused</i></td>
       <td>
         {{BufferSource}} or<br>
-        {{NDEFMessage}}
+        {{NDEFMessageInit}}
       </td>
       <td><a>External type record</a></td>
       <td>4</td>


### PR DESCRIPTION
This PR replaces NDEFRecord `any data` with `NDEFRecordSource data`. The new `NDEFRecordSource` is `typedef (DOMString or BufferSource or NDEFMessageInit)`

```js
const textRecord = new NDEFRecord({ recordType: "text", data: "foo" });
```

FIX #453


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/454.html" title="Last updated on Nov 27, 2019, 8:27 AM UTC (8c08a71)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/454/61d614b...beaufortfrancois:8c08a71.html" title="Last updated on Nov 27, 2019, 8:27 AM UTC (8c08a71)">Diff</a>