### PR TITLE
Disallow id for an empty NDEF record

### DIFF
--- a/index.html
+++ b/index.html
@@ -2800,6 +2800,10 @@
             [= exception/throw =] a {{TypeError}} and abort these steps.
           </li>
           <li>
+            If |record|'s <a>id</a> is not `undefined`,
+            [= exception/throw =] a {{TypeError}} and abort these steps.
+          </li>
+          <li>
             Let |ndef| be the notation for the <a>NDEF record</a> to
             be created by the UA.
           </li>


### PR DESCRIPTION
As stated in https://w3c.github.io/web-nfc/#empty-ndef-record-tnf-0, an empty record's' TYPE LENGTH field, ID LENGTH field and PAYLOAD LENGTH field MUST be 0, thus the TYPE field, **ID field** and PAYLOAD field **MUST NOT be present.**

This PR makes sure id is forbidden for an empty NDEF record.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/460.html" title="Last updated on Dec 6, 2019, 12:19 PM UTC (0289199)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/460/06671e6...beaufortfrancois:0289199.html" title="Last updated on Dec 6, 2019, 12:19 PM UTC (0289199)">Diff</a>