### PR TITLE
s/undefined/null/g for |data| when empty payload

### DIFF
--- a/index.html
+++ b/index.html
@@ -3958,7 +3958,7 @@
         <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of
           |ndefRecords|'s <a>PAYLOAD field</a> if that exists, or otherwise
-          `undefined`.
+          `null`.
         </li>
         <li>
           Set |record|'s <a>data</a> to |buffer|.
@@ -4010,7 +4010,7 @@
         <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of
           |ndefRecords|'s <a>PAYLOAD field</a> if that exists, or otherwise
-          `undefined`.
+          `null`.
         </li>
         <li>
           Set |record|'s <a>data</a> to |buffer|.
@@ -4036,7 +4036,7 @@
         <li>
           Let |buffer:byte sequence| be the <a>byte sequence</a> of
           |ndefRecords|'s <a>PAYLOAD field</a> if that exists, or otherwise
-          `undefined`.
+          `null`.
         </li>
         <li>
           Set |record|'s <a>data</a> to |buffer|.

--- a/index.html
+++ b/index.html
@@ -3717,6 +3717,9 @@
           <li>
             Set |record|'s <a>mediaType</a> to `null`.
           </li>
+          <li>
+            Set |record|'s <a>data</a> to `null`.
+          </li>
         </ol>
       </li>
       <li>


### PR DESCRIPTION
FIX #462


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/463.html" title="Last updated on Dec 12, 2019, 8:28 AM UTC (e89b33a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/463/27f97a9...beaufortfrancois:e89b33a.html" title="Last updated on Dec 12, 2019, 8:28 AM UTC (e89b33a)">Diff</a>