### PR TITLE
s/smartPosterRecord/externalRecord

### DIFF
--- a/index.html
+++ b/index.html
@@ -1371,13 +1371,13 @@
       const reader = new NDEFReader();
       await reader.scan({ recordType: "example.com:smart-poster" });
       reader.onreading = event => {
-        const smartPosterRecord = event.message.records.find(
+        const externalRecord = event.message.records.find(
           record => record.type == "example.com:smart-poster"
         );
 
         let action, text;
 
-        for (const record of smartPosterRecord.toRecords()) {
+        for (const record of externalRecord.toRecords()) {
           if (record.recordType == "text") {
             const decoder = new TextDecoder(record.encoding);
             text = decoder.decode(record.data);


### PR DESCRIPTION
I think renaming `smartPosterRecord` to `externalRecord` makes it clearer it's not a real "smart-poster" record. Sorry for the confusion


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/pull/468.html" title="Last updated on Dec 13, 2019, 8:26 AM UTC (874a219)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/468/f7cdd2d...874a219.html" title="Last updated on Dec 13, 2019, 8:26 AM UTC (874a219)">Diff</a>