### PR TITLE
Return and resolve promise in reader.scan

### DIFF
--- a/index.html
+++ b/index.html
@@ -3422,13 +3422,12 @@
             </ol>
           </li>
           <li>
-            Run the following steps <a>in parallel</a>:
+            Return |p| and run the following steps <a>in parallel</a>:
             <ol>
               <li>
-                If the <a>obtain permission</a> steps return
-                `false`, then reject |p| with a
-                {{"NotAllowedError"}} {{DOMException}}
-                and return |p|.
+                If the <a>obtain permission</a> steps return `false`, then
+                reject |p| with a {{"NotAllowedError"}} {{DOMException}} and
+                abort these steps.
               </li>
               <li>
                 If this is the first listener being set up, then make a request
@@ -3436,8 +3435,7 @@
               </li>
               <li>
                 If the request fails, then the UA MAY reject |p| with a
-                {{"NotSupportedError"}} {{DOMException}}
-                and return |p|.
+                {{"NotSupportedError"}} {{DOMException}} and abort these steps.
               </li>
               <li>
                 Add |reader| to the <a>activated reader objects</a>.
@@ -3453,6 +3451,9 @@
               <li>
                 Whenever the <a>UA</a> detects NFC technology, run the
                 <a>NFC reading algorithm</a>.
+              </li>
+              <li>
+                Resolve |p|.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
This PR makes sure `NDEFReader.scan` says when it resolves and returns the promise `p`.

This issue was raised in https://github.com/w3c/web-nfc/issues/478


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/480.html" title="Last updated on Dec 18, 2019, 7:33 AM UTC (ecb45a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/480/50dbabb...beaufortfrancois:ecb45a0.html" title="Last updated on Dec 18, 2019, 7:33 AM UTC (ecb45a0)">Diff</a>