### PR TITLE
Resolve scan promise after reader is activated

### DIFF
--- a/index.html
+++ b/index.html
@@ -3441,6 +3441,9 @@
                 Add |reader| to the <a>activated reader objects</a>.
               </li>
               <li>
+                Resolve |p|.
+              </li>
+              <li>
                 If the {{Document}} of the <a>top-level browsing context</a> is
                 not <a>visible</a> (e.g. the user navigated
                 to another page), then the registered
@@ -3451,9 +3454,6 @@
               <li>
                 Whenever the <a>UA</a> detects NFC technology, run the
                 <a>NFC reading algorithm</a>.
-              </li>
-              <li>
-                Resolve |p|.
               </li>
             </ol>
           </li>


### PR DESCRIPTION
As suggested at https://github.com/w3c/web-nfc/issues/478#issuecomment-567674050, scan promise should resolve just after reader is added to activated reader objects.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/483.html" title="Last updated on Dec 23, 2019, 8:31 AM UTC (b1b97f8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/483/576799b...beaufortfrancois:b1b97f8.html" title="Last updated on Dec 23, 2019, 8:31 AM UTC (b1b97f8)">Diff</a>