### PR TITLE
Remove request to adapters to listen to NDEF messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3430,14 +3430,6 @@
                 abort these steps.
               </li>
               <li>
-                If this is the first listener being set up, then make a request
-                to all <a>NFC adapter</a>s to listen to <a>NDEF message</a>s.
-              </li>
-              <li>
-                If the request fails, then the UA MAY reject |p| with a
-                {{"NotSupportedError"}} {{DOMException}} and abort these steps.
-              </li>
-              <li>
                 Add |reader| to the <a>activated reader objects</a>.
               </li>
               <li>

--- a/index.html
+++ b/index.html
@@ -3318,7 +3318,8 @@
   <section> <h3>Listening for content</h3>
     <p>
       If there are any {{NDEFReader}} instances in <a>activated reader objects</a>
-      then the <a>UA</a> MUST listen to <a>NDEF message</a>s.
+      then the <a>UA</a> MUST listen to <a>NDEF message</a>s on all connected
+      NFC adapters.
     </p>
     <p>
       To listen for <a>NFC content</a>, the client MUST activate an


### PR DESCRIPTION
I think* we can remove the part where we "make a request to all NFC adapters to listen to NDEF messages" in scan promise as we're already saying that "If there are any NDEFReader instances in activated reader objects then the UA MUST listen to NDEF messages." See https://w3c.github.io/web-nfc/#listening-for-content

Note that we've already checked NFC adapter existence and if NFC connection can be established at that point.

Context: https://github.com/w3c/web-nfc/issues/478#issuecomment-568401815


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/484.html" title="Last updated on Dec 24, 2019, 6:32 AM UTC (d54bf27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/484/1ea511c...beaufortfrancois:d54bf27.html" title="Last updated on Dec 24, 2019, 6:32 AM UTC (d54bf27)">Diff</a>