### PR TITLE
Add SecureContext to NDEFRecord and NDEFMessage interfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -1488,7 +1488,7 @@
       <a>NDEFMessage</a> interface:
     </p>
     <pre class="idl">
-      [Exposed=Window]
+      [SecureContext, Exposed=Window]
       interface NDEFMessage {
         constructor(NDEFMessageInit messageInit);
         readonly attribute FrozenArray&lt;NDEFRecord&gt; records;
@@ -1517,7 +1517,7 @@
     <pre class="idl">
       typedef (DOMString or BufferSource or NDEFMessageInit) NDEFRecordDataSource;
 
-      [Exposed=Window]
+      [SecureContext, Exposed=Window]
       interface NDEFRecord {
         constructor(NDEFRecordInit recordInit);
 


### PR DESCRIPTION
NDEFRecord and NDEFMessage interfaces should only be accessible to secure contexts. This PR makes sures it is the case.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/485.html" title="Last updated on Dec 23, 2019, 12:18 PM UTC (5b890eb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/485/1ea511c...beaufortfrancois:5b890eb.html" title="Last updated on Dec 23, 2019, 12:18 PM UTC (5b890eb)">Diff</a>