### PR TITLE
Remove redundant info from scan algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -3437,14 +3437,6 @@
                 Resolve |p|.
               </li>
               <li>
-                If the {{Document}} of the <a>top-level browsing context</a> is
-                not <a>visible</a> (e.g. the user navigated
-                to another page), then the registered
-                <a>activated reader objects</a> still SHOULD continue to exist,
-                but SHOULD become paused, i.e. the UA SHOULD NOT check and use
-                them until the {{Document}} is <a>visible</a> again.
-              </li>
-              <li>
                 Whenever the <a>UA</a> detects NFC technology, run the
                 <a>NFC reading algorithm</a>.
               </li>


### PR DESCRIPTION
As agreed in https://github.com/w3c/web-nfc/issues/478#issuecomment-568681060, this PR removes redundant info from scan algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/486.html" title="Last updated on Dec 24, 2019, 7:37 AM UTC (2687ff5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/486/7c1b559...beaufortfrancois:2687ff5.html" title="Last updated on Dec 24, 2019, 7:37 AM UTC (2687ff5)">Diff</a>