### PR TITLE
Make NDEFRecord.toRecords() nullable

### DIFF
--- a/index.html
+++ b/index.html
@@ -1529,7 +1529,7 @@
         readonly attribute USVString? encoding;
         readonly attribute USVString? lang;
 
-        sequence&lt;NDEFRecord&gt; toRecords();
+        sequence&lt;NDEFRecord&gt;? toRecords();
       };
 
       dictionary NDEFRecordInit {
@@ -3587,6 +3587,9 @@
     To <dfn>parse records from bytes</dfn> given |bytes:byte sequence|,
     run these steps:
     <ol class=algorithm>
+      <li>
+        If the length of |bytes| is `0`, return `null` and abort these steps.
+      </li>
       <li>
         Let |records| be the empty list.
       </li>


### PR DESCRIPTION
FIX https://github.com/w3c/web-nfc/issues/487


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/489.html" title="Last updated on Dec 24, 2019, 9:51 AM UTC (a05ba0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/489/019d78f...beaufortfrancois:a05ba0e.html" title="Last updated on Dec 24, 2019, 9:51 AM UTC (a05ba0e)">Diff</a>