### PR TITLE
Don't throw exception in 'parse records from bytes'

### DIFF
--- a/index.html
+++ b/index.html
@@ -1632,7 +1632,6 @@
         If the |recordType| value is "`smart-poster`", or if running
         <a>validate external type</a> on |recordType| returns `true`,
         then return the result of running <a>parse records from bytes</a> on |bytes|.
-        Re-[= exception/throw =] any exceptions.
       </li>
       <li>
         Otherwise, [= exception/throw =] a
@@ -3598,12 +3597,13 @@
         sub-steps:
         <ol>
           <li>
-            If the remaining length of |bytes| is less than `3`, abort these
-            sub-steps.
+            If the remaining length of |bytes| is less than `3`, return `null`
+            and abort these sub-steps.
           </li>
           <li>
             If any of the following steps requires reading bytes beyond the
-            remaining length of |bytes|, return |records|.
+            remaining length of |bytes|, return `null` and abort these
+            sub-steps.
           </li>
           <li>
             Let |ndef| be the notation for the current <a>NDEF record</a>.
@@ -3617,8 +3617,8 @@
               </li>
               <li>
                 If this is the first iteration of these sub-steps and
-                |messageBegin| is `false`,
-                return |records|.
+                |messageBegin| is `false`, return `null` and abort these
+                sub-steps.
               </li>
               <li>
                 Let |messageEnd:boolean| (<a>ME field</a>) be bit 6 of |header|.


### PR DESCRIPTION
Following https://github.com/w3c/web-nfc/pull/489#discussion_r361127710 and https://github.com/w3c/web-nfc/pull/489#issuecomment-568716289, this PR makes sure an invalid NDEF Message contained in an `Sp/external` type record returns `null` for `toRecords()` instead of throwing an exception.

WDYT @leonhsl


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/490.html" title="Last updated on Dec 24, 2019, 10:51 AM UTC (99b5b67)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/490/7c4100c...beaufortfrancois:99b5b67.html" title="Last updated on Dec 24, 2019, 10:51 AM UTC (99b5b67)">Diff</a>