### PR TITLE
Set empty record id to null

### DIFF
--- a/index.html
+++ b/index.html
@@ -3708,6 +3708,9 @@
         (<a>empty record</a>):
         <ol>
           <li>
+            Set |record|'s <a>id</a> to `null`.
+          </li>
+          <li>
             Set |record|'s <a>recordType</a> to "`empty`".
           </li>
           <li>


### PR DESCRIPTION
This PR sets empty record `id` to `null` as NFC Forum spec says the ID field is omitted from the NDEF record.

FIX https://github.com/w3c/web-nfc/issues/465


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/492.html" title="Last updated on Dec 24, 2019, 1:08 PM UTC (989d616)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/492/910b21d...beaufortfrancois:989d616.html" title="Last updated on Dec 24, 2019, 1:08 PM UTC (989d616)">Diff</a>