### PR TITLE
Fix isLocal algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -2757,10 +2757,28 @@
             </ul>
           </li>
           <li>
-            If |record|'s <a>isLocal</a> is `true` and |record| is not a payload
-            to another <a>NDEF record</a>, reject |promise| with a {{TypeError}}
-            and abort these steps.
-          </li>
+            If |record|'s <a>isLocal</a> is `true`:
+            <ul>
+              <li>
+                If |record| is not a payload to another <a>NDEF record</a>,
+                reject |promise| with a {{TypeError}} and abort these steps.
+              </li>
+              <li>
+                If running the <a>validate local type</a> steps on |record|'s
+                <a>recordType</a> returns `false`, reject |promise| with a
+                {{TypeError}} and abort these steps.
+              </li>
+              <li>
+                If |record|'s <a>data</a> is of type
+                {{NDEFMessageInit}}, then return the result of running
+                the <a>create NDEF message</a> given |record|'s
+                <a>data</a>.
+              </li>
+              <li>
+                Otherwise, return the result of running
+                <a>map local type to NDEF</a> given |record| and |ndef|.
+              </li>
+            </ul>
           <li>
             Switching on |record|'s <a>recordType</a>, pass |record| and |ndef|
             to one of the following algorithms and return the result.
@@ -2807,23 +2825,6 @@
               <li>
                 Otherwise, return <a>map external data to NDEF</a> given
                 |record| and |ndef|.
-              </li>
-            </ul>
-          </li>
-          <li>
-            If |record| is a payload to another <a>NDEF record</a> and if
-            running the <a>validate local type</a> steps on |record|'s
-            <a>recordType</a> returns `true`,
-            <ul>
-              <li>
-                If |record|'s <a>data</a> is of type
-                {{NDEFMessageInit}}, then return the result of running
-                the <a>create NDEF message</a> given |record|'s
-                <a>data</a>.
-              </li>
-              <li>
-                Otherwise, return the result of running
-                <a>map local type to NDEF</a> given |record| and |ndef|.
               </li>
             </ul>
           </li>
@@ -3722,8 +3723,7 @@
         Set |record|'s <a>id</a> to |ndef|'s |id:string|.
       </li>
       <li>
-        Set |record|'s <a>isLocal</a> to `true` if |ndef| is a payload
-        to another <a>NDEF record</a>, or otherwise `false`.
+        Set |record|'s <a>isLocal</a> to `false`.
       </li>
       <li>
         Set |record|'s <a>lang</a> to `null`.
@@ -3752,6 +3752,10 @@
       <li>
         If |ndef|'s |typeNameField| is `1` ([=well-known type record=]):
         <ol>
+          <li>
+            Set |record|'s <a>isLocal</a> to `true` if |ndef| is a payload
+            to another <a>NDEF record</a>.
+          </li>
           <li>
             Set |record| to the result of the algorithm below switching on
             |ndef|'s |type:string|:


### PR DESCRIPTION
As suggested by @leonhsl at  https://github.com/w3c/web-nfc/pull/491#issuecomment-568853627 and https://github.com/w3c/web-nfc/pull/491#issuecomment-568854522, this PR refactors "Creating NDEF record" algorithm for `isLocal` and makes sure we set `isLocal=true` only for TNF=1 records.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/493.html" title="Last updated on Dec 25, 2019, 9:00 AM UTC (3834de0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/493/f445c52...beaufortfrancois:3834de0.html" title="Last updated on Dec 25, 2019, 9:00 AM UTC (3834de0)">Diff</a>