### PR TITLE
Add Page Visibility example

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -151,9 +151,10 @@ document.querySelector("#abortButton").onclick = event => {
 
 ## Integration with Page Visibility
 
-Web NFC functionality is allowed only for the Document of the top-level browsing
-context, which must be visible. Thanks to the Page Visibility API, web
-developers can track when it document visibility changes.
+Web NFC functionality is allowed only for the document of the top-level browsing
+context, which must be visible. Thanks to the
+[Page Visibility API](https://developer.mozilla.org/en-US/docs/Web/API/Page_Visibility_API),
+web developers can track when it document visibility changes.
 
 ```js
 document.onvisibilitychange = event => {

--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -149,6 +149,22 @@ document.querySelector("#abortButton").onclick = event => {
 };
 ```
 
+## Integration with Page Visibility
+
+Web NFC functionality is allowed only for the Document of the top-level browsing
+context, which must be visible. Thanks to the Page Visibility API, web
+developers can track when it document visibility changes.
+
+```js
+document.onvisibilitychange = event => {
+  if (document.hidden) {
+    // All NFC operations are automatically suspended when document is hidden.
+  } else {
+    // All NFC operations are resumed, if needed.
+  }
+};
+```
+
 ## Detailed design discussion
 
 ### Low level API vs standardized NDEF records only


### PR DESCRIPTION
This PR adds to the explainer the Page Visibility API to the list of APIs that interact well with Web NFC.