### PR TITLE
Replace isLocal by colon prefix in recordType

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -112,7 +112,7 @@ reader.onreading = event => {
   let action, text;
 
   for (const record of externalRecord.toRecords()) {
-    if (record.recordType == "text" && !record.isLocal) {
+    if (record.recordType == "text") {
       const decoder = new TextDecoder(record.encoding);
       text = decoder.decode(record.data);
     } else if (record.recordType == "act") {

--- a/index.html
+++ b/index.html
@@ -1318,18 +1318,15 @@
               data: "Funny dance"
             },
             {
-              recordType: "t",  // type record, a local type to Sp
-              isLocal: true,
+              recordType: ":t",  // type record, a local type to Sp
               data: encoder.encode("image/gif") // MIME type of the Sp content
             },
             {
-              recordType: "s",  // size record, a local type to Sp
-              isLocal: true,
+              recordType: ":s",  // size record, a local type to Sp
               data: new Uint32Array([4096]) // byte size of Sp content
             },
             {
-              recordType: "act",  // action record, a local type to Sp
-              isLocal: true,
+              recordType: ":act",  // action record, a local type to Sp
               // do the action, in this case open in the browser
               data: new Uint8Array([0])
             },
@@ -1382,7 +1379,7 @@
         let action, text;
 
         for (const record of externalRecord.toRecords()) {
-          if (record.recordType == "text" && !record.isLocal) {
+          if (record.recordType == "text") {
             const decoder = new TextDecoder(record.encoding);
             text = decoder.decode(record.data);
           } else if (record.recordType == "act") {
@@ -1527,7 +1524,6 @@
         readonly attribute USVString recordType;
         readonly attribute USVString? mediaType;
         readonly attribute USVString? id;
-        readonly attribute boolean isLocal;
         readonly attribute DataView? data;
 
         readonly attribute USVString? encoding;
@@ -1540,7 +1536,6 @@
         required USVString recordType;
         USVString mediaType;
         USVString id;
-        boolean isLocal = false;
 
         USVString encoding;
         USVString lang;
@@ -1565,10 +1560,6 @@
         the message (collection of records), and it may be present when no payload is.
       </p>
     </div>
-    <p>
-      The <dfn>isLocal</dfn> property represents whether or not the <a>NDEF
-      record</a> is of <a>local type</a>.
-    </p>
     <p>
       The <dfn>encoding</dfn> attribute represents the
       [=encoding/name|encoding name=] used for encoding the payload in the
@@ -1602,9 +1593,9 @@
     </p>
     <p data-dfn-for="NDEFRecordInit">
       The <dfn>NDEFRecordInit</dfn> dictionary is used to initialize an
-      <a>NDEF record</a> with its <a>record type</a> <dfn>recordType</dfn>,
-      <a>local type</a> <dfn>isLocal</dfn>, and optional <a>record
-      identifier</a> <dfn>id</dfn> and payload data <dfn>data</dfn>.
+      <a>NDEF record</a> with its <a>record type</a> <dfn>recordType</dfn>, and
+      optional <a>record identifier</a> <dfn>id</dfn> and payload data
+      <dfn>data</dfn>.
     </p>
     <div data-dfn-for="NDEFRecordInit">
       Additionally, there are additional optional fields that are only applicable
@@ -1847,7 +1838,6 @@
       <th nowrap>[=TYPE field=]</th>
       <th>[=recordType=]</th>
       <th>[=mediaType=]</th>
-      <th>[=isLocal=]</th>
     </tr>
     <tr>
       <td>[=Empty record=]</td>
@@ -1855,7 +1845,6 @@
       <td><i>unused</i></td>
       <td>"`empty`"</td>
       <td>`null`</td>
-      <td>`false`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
@@ -1863,7 +1852,6 @@
       <td>"`T`"</td>
       <td>"`text`"</td>
       <td>`null`</td>
-      <td>`false`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
@@ -1871,7 +1859,6 @@
       <td>"`U`"</td>
       <td>"`url`"</td>
       <td>`null`</td>
-      <td>`false`</td>
     </tr>
     <tr>
       <td>[=Well-known type record=]</td>
@@ -1879,7 +1866,6 @@
       <td>"`Sp`"</td>
       <td nowrap>"`smart-poster`"</td>
       <td>`null`</td>
-      <td>`false`</td>
     </tr>
     <tr>
       <td>[=Local type=] record*</td>
@@ -1887,7 +1873,6 @@
       <td>[=local type name=]</td>
       <td>[=local type name=]</td>
       <td>`null`</td>
-      <td>`true`</td>
     </tr>
     <tr>
       <td>[=MIME type record=]</td>
@@ -1895,7 +1880,6 @@
       <td>[=MIME type=]</td>
       <td>"`mime`"</td>
       <td>The <a>MIME type</a> used in the NDEF record</td>
-      <td>`false`</td>
     </tr>
     <tr>
       <td>[=Absolute-URL record=]</td>
@@ -1903,7 +1887,6 @@
       <td>URL</td>
       <td>"`absolute-url`"</td>
       <td>`null`</td>
-      <td>`false`</td>
     </tr>
     <tr>
       <td>[=External type record=]</a></td>
@@ -1911,7 +1894,6 @@
       <td>[=external type name=]</td>
       <td>[=external type name=]</td>
       <td>`null`</td>
-      <td>`false`</td>
     </tr>
     <tr>
       <td><a>Unknown record</a></td>
@@ -1919,7 +1901,6 @@
       <td><i>unused</i></td>
       <td>"`unknown`"</td>
       <td>`null`</td>
-      <td>`false`</td>
     </tr>
   </table>
   </section>
@@ -2730,7 +2711,7 @@
             </ul>
           </li>
           <li>
-            If |record|'s <a>isLocal</a> is `true`:
+            If |record|'s <a>recordType</a> starts with a colon `U+003A` (`:`):
             <ul>
               <li>
                 If |record| is not a payload to another <a>NDEF record</a>,
@@ -2888,12 +2869,16 @@
       </p>
       <ol class=algorithm id="validate-local-type">
         <li>
-          If |input| is not a {{USVString}} or its length exceeds 255 bytes,
-          return `false` and abort these steps.
+          Let |localTypeName| be the |input| after the first occurrence of
+          `U+003A` (`:`) up to the end of |input|.
         </li>
         <li>
-          If |input| does not start with a lowercase character or a number,
-          return `false`.
+          If |localTypeName| is not a {{USVString}} or its length exceeds 255
+          bytes, return `false` and abort these steps.
+        </li>
+        <li>
+          If |localTypeName| does not start with a lowercase character or a
+          number, return `false`.
         </li>
         <li>
           If |input| is equal to the <a>record type</a> of any <a>NDEF record</a>
@@ -3292,8 +3277,13 @@
             ([=well-known type record=]).
           </li>
           <li>
-            Set |ndef|'s <a>TYPE field</a> to |record|'s
-            <a>recordType</a>, representing the <a>local type</a> name.
+            Let |localTypeName| be the |record|'s <a>recordType</a> after the
+            first occurrence of `U+003A` (`:`) up to the end of |record|'s
+            <a>recordType</a>.
+          </li>
+          <li>
+            Set |ndef|'s <a>TYPE field</a> to |localTypeName|, representing the
+            <a>local type name</a>.
           </li>
           <li>
             If the type of a |record|'s <a>data</a> is a {{BufferSource}},
@@ -3761,9 +3751,6 @@
         Set |record|'s <a>id</a> to |ndef|'s |id:string|.
       </li>
       <li>
-        Set |record|'s <a>isLocal</a> to `false`.
-      </li>
-      <li>
         Set |record|'s <a>lang</a> to `null`.
       </li>
       <li>
@@ -3790,10 +3777,6 @@
       <li>
         If |ndef|'s |typeNameField| is `1` ([=well-known type record=]):
         <ol>
-          <li>
-            Set |record|'s <a>isLocal</a> to `true` if |ndef| is a payload
-            to another <a>NDEF record</a>.
-          </li>
           <li>
             Set |record| to the result of the algorithm below switching on
             |ndef|'s |type:string|:


### PR DESCRIPTION
As proposed in https://github.com/w3c/web-nfc/issues/501, this PR gets rid of the new `isLocal` and replaces it with a colon prefix in `recordType`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/502.html" title="Last updated on Jan 2, 2020, 2:14 PM UTC (cca312d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/502/7b4431b...beaufortfrancois:cca312d.html" title="Last updated on Jan 2, 2020, 2:14 PM UTC (cca312d)">Diff</a>