### PR TITLE
Add local type records example to data mapping tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -1737,9 +1737,9 @@
       <th>[=recordType=]</th>
       <th>[=mediaType=]</th>
       <th>[=data=]</th>
-      <th><a href="#ndef-record-types">record type</a></th>
+      <th nowrap><a href="#ndef-record-types">record type</a></th>
       <th nowrap>[=TNF field=]</th>
-      <th>[=TYPE field=]</th>
+      <th nowrap>[=TYPE field=]</th>
     </tr>
     <tr>
       <td><dfn>"`empty`"</dfn></td>
@@ -1777,14 +1777,14 @@
       <td>"`Sp`"</td>
     </tr>
     <tr>
-      <td><i>[=local type name=]</i></td>
+      <td>[=local type name=] prefixed by a colon `U+003A` (`:`), e.g., "`:act`", "`:s`", and "`:t`"</td>
       <td><i>unused</i></td>
       <td>
         {{BufferSource}} or {{NDEFMessageInit}}
       </td>
       <td>[=Local type=] record*</td>
       <td>1</td>
-      <td>[=local type name=]</td>
+      <td>[=local type name=], e.g., "`act`", "`s`", and "`t`"</td>
     </tr>
     <tr>
       <td><dfn>"`mime`"</dfn></td>
@@ -1870,8 +1870,8 @@
     <tr>
       <td>[=Local type=] record*</td>
       <td>1</td>
-      <td>[=local type name=]</td>
-      <td>[=local type name=]</td>
+      <td>[=local type name=], e.g., "`act`", "`s`", and "`t`"</td>
+      <td>[=local type name=] prefixed by a colon `U+003A` (`:`), e.g., "`:act`", "`:s`", and "`:t`"</td>
       <td>`null`</td>
     </tr>
     <tr>


### PR DESCRIPTION
This PR adds some examples for local type records in data mapping tables so that it's clear for users how Web NFC differs from NFC Forum spec.

Fix https://github.com/w3c/web-nfc/issues/504


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/506.html" title="Last updated on Jan 3, 2020, 7:59 AM UTC (504677f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/506/6baaec4...beaufortfrancois:504677f.html" title="Last updated on Jan 3, 2020, 7:59 AM UTC (504677f)">Diff</a>