### PR TITLE
Fix nits in JS example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1151,7 +1151,7 @@
                 console.log(`JSON: ${JSON.parse(decoder.decode(record.data))}`);
               }
               else if (record.mediaType.startsWith('image/')) {
-                const blob = new Blob([record.data], {type: record.mediaType});
+                const blob = new Blob([record.data], { type: record.mediaType });
 
                 const img = document.createElement("img");
                 img.src = URL.createObjectURL(blob);
@@ -1163,6 +1163,8 @@
                 console.log(`Media not handled`);
               }
               break;
+            default:
+              console.log(`Record not handled`);
           }
         }
       };


### PR DESCRIPTION
This PR adds a `console.log` in a JS example when record type is not handled.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/508.html" title="Last updated on Jan 3, 2020, 8:23 AM UTC (41020a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/508/6baaec4...beaufortfrancois:41020a8.html" title="Last updated on Jan 3, 2020, 8:23 AM UTC (41020a8)">Diff</a>