### PR TITLE
Add create steps for absolute-URL records

### DIFF
--- a/index.html
+++ b/index.html
@@ -2766,7 +2766,13 @@
                   |ndef|.
                 </li>
               </ul>
-              <!-- TODO: "absolute-url" -->
+              <dt>"`absolute-url`"</dt>
+              <ul>
+                <li>
+                  Return <a>map absolute-URL to NDEF</a> given |record| and
+                  |ndef|.
+                </li>
+              </ul>
             </dl>
           </li>
           <li>
@@ -3356,6 +3362,43 @@
           <li>
             Set |ndef|'s <a>PAYLOAD LENGTH field</a> to the length of
             |ndef|'s <a>PAYLOAD field</a>.
+          </li>
+          <li>
+            Return |ndef|.
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <section><h3>Mapping absolute-URL to NDEF</h3>
+      <div>
+        To <dfn>map absolute-URL to NDEF</dfn> given a |record:NDEFRecordInit|
+        and |ndef|, run these steps:
+        <ol class=algorithm data-link-for="NDEFRecord">
+          <li>
+            If |record|'s <a>mediaType</a> is not `undefined`,
+            [= exception/throw =] a {{TypeError}} and abort these steps.
+          </li>
+          <li>
+            If |record|'s <a>data</a> is not a {{DOMString}},
+            [= exception/throw =] a {{TypeError}} and abort these steps.
+          </li>
+          <li>
+            If the result of <a data-lt="url parser">parsing</a> |record|'s
+            <a>data</a> is failure, [= exception/throw =] a
+            {{SyntaxError}} and abort these steps.
+          </li>
+          <li>
+            Set |arrayBuffer| to |record|'s <a>data</a>.
+          </li>
+          <li>
+            Set |data:byte sequence| to |arrayBuffer|.[[\ArrayBufferData]].
+          </li>
+          <li>
+            Set the |ndef|'s <a>TNF field</a> to `3` ([=absolute-URL record=]).
+          </li>
+          <li>
+            Set the |ndef|'s <a>TYPE field</a> to |data|.
           </li>
           <li>
             Return |ndef|.

--- a/index.html
+++ b/index.html
@@ -3395,10 +3395,14 @@
             Set |data:byte sequence| to |arrayBuffer|.[[\ArrayBufferData]].
           </li>
           <li>
-            Set the |ndef|'s <a>TNF field</a> to `3` ([=absolute-URL record=]).
+            Set |ndef|'s <a>TNF field</a> to `3` ([=absolute-URL record=]).
           </li>
           <li>
-            Set the |ndef|'s <a>TYPE field</a> to |data|.
+            Set |ndef|'s <a>TYPE field</a> to |data|.
+          </li>
+          <li>
+            Set |ndef|'s <a>PAYLOAD LENGTH field</a> to `0` and omit <a>PAYLOAD
+            field</a>.
           </li>
           <li>
             Return |ndef|.


### PR DESCRIPTION
This PR adds missing steps for creating absolute-URL records.

Fix https://github.com/w3c/web-nfc/issues/509


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/512.html" title="Last updated on Jan 3, 2020, 1:41 PM UTC (0f2102a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/512/b1a2853...beaufortfrancois:0f2102a.html" title="Last updated on Jan 3, 2020, 1:41 PM UTC (0f2102a)">Diff</a>