### PR TITLE
Add missing obtain permission in NDEFWriter.push algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -2413,6 +2413,11 @@
                 </p>
               </li>
               <li>
+                If the <a>obtain permission</a> steps return `false`, then
+                reject |p| with a {{"NotAllowedError"}} {{DOMException}} and
+                abort these steps.
+              </li>
+              <li>
                 Let |output| be the notation for the <a>NDEF message</a>
                 to be created by UA, as the result of passing
                 |message| to <a>create NDEF message</a>.


### PR DESCRIPTION
I realized that our  NDEFWriter.push algorithm did not require explicitly user permission. This PR fixes that and makes it on a par with NDEFReader.scan algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/528.html" title="Last updated on Jan 9, 2020, 1:17 PM UTC (5633b28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/528/d12fac4...beaufortfrancois:5633b28.html" title="Last updated on Jan 9, 2020, 1:17 PM UTC (5633b28)">Diff</a>