### PR TITLE
User permission is required before checking NFC adapter/setting state

### DIFF
--- a/index.html
+++ b/index.html
@@ -2352,23 +2352,6 @@
             Let |options:NDEFPushOptions| be the second argument.
           </li>
           <li>
-            If there is no underlying <a>NFC Adapter</a>, or if a connection
-            cannot be established, then reject |p| with a
-            {{"NotSupportedError"}} {{DOMException}}
-            and return |p|.
-          </li>
-          <li>
-            If the UA is not allowed to access the underlying <a>NFC Adapter</a>
-            (e.g. a user preference), then reject |p| with a
-            {{"NotReadableError"}} {{DOMException}}
-            and return |p|.
-          </li>
-          <li>
-            If pushing data is not supported by the underlying
-            <a>NFC Adapter</a>, then reject |p| with a {{"NotSupportedError"}}
-            {{DOMException}} and return |p|.
-          </li>
-          <li>
             Let |signal:AbortSignal| be the |options|’ dictionary member
             of the same name if present, or `null` otherwise.
           </li>
@@ -2400,6 +2383,28 @@
             Return |p| and run the following steps <a>in parallel</a>:
             <ol>
               <li>
+                If the <a>obtain permission</a> steps return `false`, then
+                reject |p| with a {{"NotAllowedError"}} {{DOMException}} and
+                abort these steps.
+              </li>
+              <li>
+                If there is no underlying <a>NFC Adapter</a>, or if a connection
+                cannot be established, then reject |p| with a
+                {{"NotSupportedError"}} {{DOMException}}
+                and return |p|.
+              </li>
+              <li>
+                If the UA is not allowed to access the underlying <a>NFC Adapter</a>
+                (e.g. a user preference), then reject |p| with a
+                {{"NotReadableError"}} {{DOMException}}
+                and return |p|.
+              </li>
+              <li>
+                If pushing data is not supported by the underlying
+                <a>NFC Adapter</a>, then reject |p| with a {{"NotSupportedError"}}
+                {{DOMException}} and return |p|.
+              </li>
+              <li>
                 An implementation MAY reject |p| with
                 a {{"NotSupportedError"}} {{DOMException}}
                 and abort these steps.
@@ -2411,11 +2416,6 @@
                   Also, the implementation might be unable to support the
                   requested operation.
                 </p>
-              </li>
-              <li>
-                If the <a>obtain permission</a> steps return `false`, then
-                reject |p| with a {{"NotAllowedError"}} {{DOMException}} and
-                abort these steps.
               </li>
               <li>
                 Let |output| be the notation for the <a>NDEF message</a>
@@ -3420,18 +3420,6 @@
             </ol>
           </li>
           <li>
-            If there is no underlying <a>NFC Adapter</a>, or if a connection
-            cannot be established, then reject |p| with a
-            {{"NotSupportedError"}} {{DOMException}}
-            and return |p|.
-          </li>
-          <li>
-            If the UA is not allowed to access the underlying <a>NFC Adapter</a>
-            (e.g. a user preference), then reject |p| with a
-            {{"NotReadableError"}} {{DOMException}}
-            and return |p|.
-          </li>
-          <li>
             If |reader|.<a>[[\Signal]]</a>'s [= AbortSignal/aborted flag =] is
             set, then reject |p| with a {{"AbortError"}} {{DOMException}}
             and return |p|.
@@ -3459,6 +3447,18 @@
                 If the <a>obtain permission</a> steps return `false`, then
                 reject |p| with a {{"NotAllowedError"}} {{DOMException}} and
                 abort these steps.
+              </li>
+              <li>
+                If there is no underlying <a>NFC Adapter</a>, or if a connection
+                cannot be established, then reject |p| with a
+                {{"NotSupportedError"}} {{DOMException}}
+                and return |p|.
+              </li>
+              <li>
+                If the UA is not allowed to access the underlying <a>NFC Adapter</a>
+                (e.g. a user preference), then reject |p| with a
+                {{"NotReadableError"}} {{DOMException}}
+                and return |p|.
               </li>
               <li>
                 Add |reader| to the <a>activated reader objects</a>.


### PR DESCRIPTION
In order to better protect users against fingerprinting, user permission must be required before checking NFC adapter/setting state. This means web pages can't have access to the information whether NFC adapter is available or user has disabled NFC preference without asking user for permission to use Web NFC. Without this change, this is currently possible in the spec. Note that Chromium implementation already checks for user permission first before push and scan operations.

FIX #527


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/530.html" title="Last updated on Jan 10, 2020, 4:35 AM UTC (8bb8f86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/530/8c7a5fe...beaufortfrancois:8bb8f86.html" title="Last updated on Jan 10, 2020, 4:35 AM UTC (8bb8f86)">Diff</a>