### PR TITLE
encoding should be only for BufferSource data source

### DIFF
--- a/index.html
+++ b/index.html
@@ -2775,6 +2775,11 @@
               <dt>{{DOMString}}</dt>
               <ol>
                 <li>
+                  If |record|'s <a>encoding</a> is neither `undefined` nor
+                  "`utf-8`", [= exception/throw =] a {{TypeError}} and abort
+                  these steps.
+                </li>
+                <li>
                   Let |encoding label:string| be "`utf-8`".
                 </li>
               </ol>
@@ -2787,7 +2792,7 @@
                 <li>
                   If |encoding label| is not equal to "`utf-8`", "`utf-16`",
                   "`utf-16le`" or "`utf-16be`" [= exception/throw =] a
-                  {{TypeError}}.
+                  {{TypeError}} and abort these steps.
                 </li>
               </ol>
             </dl>


### PR DESCRIPTION
As raised by @leonhsl, we should throw an error if `NDEFRecordInit#encoding` is neither 'utf-8' nor `undefined` for a DOMString data source.

FIX #521


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/531.html" title="Last updated on Jan 10, 2020, 10:31 AM UTC (bb9b35d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/531/1f90f6f...beaufortfrancois:bb9b35d.html" title="Last updated on Jan 10, 2020, 10:31 AM UTC (bb9b35d)">Diff</a>