### PR TITLE
Fix local record type in JS example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1262,7 +1262,7 @@
           if (record.recordType == "text") {
             const decoder = new TextDecoder(record.encoding);
             text = decoder.decode(record.data);
-          } else if (record.recordType == "act") {
+          } else if (record.recordType == ":act") {
             action = record.data.getUint8(0);
           }
         }


### PR DESCRIPTION
@leonhsl raised this issue in our JS example at https://github.com/w3c/web-nfc/issues/505#issuecomment-572909656


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/532.html" title="Last updated on Jan 10, 2020, 10:41 AM UTC (85b1a24)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/532/1f90f6f...beaufortfrancois:85b1a24.html" title="Last updated on Jan 10, 2020, 10:41 AM UTC (85b1a24)">Diff</a>