### PR TITLE
Add blocklist.txt for managing NFC devices blocklist

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -1,0 +1,11 @@
+# This file holds a list of devices that websites using the Web NFC API are
+# forbidden from accessing.
+#
+# Each line contains the NFC-A tag's historical bytes hexadecimal values of a
+# device that should be blocked. In ISO 14443-4 terminology, the historical
+# bytes are a subset of the RATS (Request for Answer To Select) response.
+
+# Additions to this file must be made by pull request.
+
+8073C021C057597562694B6579 # YubiKey 5 series
+597562696B65794E454F7233   # YubiKey NEO


### PR DESCRIPTION
The initial contents of this blocklist.txt file have been [copied from the Chromium repository](https://source.chromium.org/chromium/chromium/src/+/master:services/device/nfc/android/java/src/org/chromium/device/nfc/NfcBlocklist.java?originalUrl=https:%2F%2Fcs.chromium.org%2F). Further entries in the blocklist should be added here so that they can be integrated into any implementation.

For info, YubiKey devices historical bytes come from https://developers.yubico.com/PIV/Introduction/Yubico_extensions.html#_answer_to_reset_atr_and_answer_to_select_ats

https://github.com/w3c/web-nfc/issues/550