### PR TITLE
 Add blocklist to the spec

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -1,0 +1,11 @@
+# This file holds a list of devices that websites using the Web NFC API are
+# forbidden from accessing.
+#
+# Each line contains the NFC-A tag's historical bytes hexadecimal values of a
+# device that should be blocked. In ISO 14443-4 terminology, the historical
+# bytes are a subset of the RATS (Request for Answer To Select) response.
+
+# Additions to this file must be made by pull request.
+
+8073C021C057597562694B6579 # YubiKey 5 series
+597562696B65794E454F7233   # YubiKey NEO

--- a/blocklist.txt
+++ b/blocklist.txt
@@ -7,5 +7,7 @@
 
 # Additions to this file must be made by pull request.
 
-8073C021C057597562694B6579 # YubiKey 5 series
-597562696B65794E454F7233   # YubiKey NEO
+# YubiKey 5 series
+8073C021C057597562694B6579
+# YubiKey NEO
+597562696B65794E454F7233

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
     adapters, for instance a built-in one, and one or more attached via USB.
   </p>
   <div>
-    An <dfn>NFC tag</dfn> is a passive NFC device.
+    An <dfn>NFC tag</dfn> is a passive NFC device that is not <a>blocklisted</a>.
     The <a>NFC tag</a> is powered by magnetic induction when an active NFC
     device is in proximity range. An <a>NFC tag</a> that supports <a>NDEF</a>
     contains a single <a>NDEF message</a>.
@@ -4273,6 +4273,63 @@
 </section>
 </section>
 
+<!-- - - - - - - - - - - - - - - The Blocklist - - - - - - - - - - - - - - - -->
+<section> <h2 id="blocklist">The Blocklist</h2>
+  <p>
+    This specification relies on a blocklist file to restrict the set of NFC
+    devices a website can access.
+  </p>
+  <p>
+    The result of <dfn>parsing the blocklist</dfn> at a |url:URL| is a list of
+    historical bytes hexadecimal values, produced by the following algorithm:
+    <ol class=algorithm>
+      <li>
+        Fetch |url:URL|, and let |contents:string| be its body, decoded as UTF-8.
+      </li>
+      <li>
+        Let |lines:array| be |contents| split on `"\n"`.
+      </li>
+      <li>
+        Let |result:list| be an empty <a>list</a>.
+      </li>
+      <li>
+        [= list/For each =] |line:string| in |lines|, run the following sub-steps:
+        <ol>
+          <li>
+            If |line| is empty, continue to the next line.
+          </li>
+          <li>
+            If |line| starts with `"#"`, continue to the next line.
+          </li>
+          <li>
+            If |line| contains invalid hexadecimal values, continue to the next line.
+          </li>
+          <li>
+            <a>Append</a> |line| to |result|.
+          </li>
+          </li>
+        </ol>
+      </li>
+      <li>
+        Return |result|.
+      </li>
+    </ol>  <!-- parsing the blocklist -->
+  </p>
+  <p>
+    The <dfn>blocklist</dfn> is the result of <a>parsing the blocklist</a> at
+    <a
+    href="https://github.com/w3c/web-nfc/blob/master/blocklist.txt">https://github.com/w3c/web-nfc/blob/master/blocklist.txt</a>.
+    The UA should re-fetch the blocklist periodically, but it’s unspecified how
+    often.
+  </p>
+  <p>
+    An <a>NFC device</a> is <dfn>blocklisted</dfn> if the <a>blocklist</a>’s
+    value contains the device's <a>historical bytes</a> hexadecimal values. In
+    ISO 14443-4 terminology, the <dfn>historical bytes</dfn> are a subset of the
+    RATS (Request for Answer To Select) response.
+  </p>
+</section>
+
 <!-- - - - - - - - - - - - - Security and Privacy - - - - - - - - - - - - - -->
 <section> <h2 id="security">Security and Privacy</h2>
   <section> <h3>Chain of trust</h3>
@@ -4634,6 +4691,13 @@
       <p>
         All permission that are preserved beyond the current
         browsing session MUST be revocable.
+      </p>
+    </section>
+
+    <section> <h4>Blocklist</h4>
+      <p>
+        Web NFC includes a <a>blocklist</a> of vulnerable NFC devices to prevent
+        websites from taking advantage of them.
       </p>
     </section>
 


### PR DESCRIPTION
This PR follows [Add blocklist.txt for managing NFC devices blocklist #552
](https://github.com/w3c/web-nfc/pull/552) to complete the integration of the blocklist in Web NFC

FIX https://github.com/w3c/web-nfc/issues/550


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/553.html" title="Last updated on Mar 30, 2020, 5:45 AM UTC (343ddb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/553/f791f8e...beaufortfrancois:343ddb2.html" title="Last updated on Mar 30, 2020, 5:45 AM UTC (343ddb2)">Diff</a>