### PR TITLE
Fix `[= dictionary member/not present =]`

### DIFF
--- a/index.html
+++ b/index.html
@@ -1852,8 +1852,7 @@
   <p data-dfn-for="NDEFReadingEventInit">
     <dfn>NDEFReadingEventInit</dfn> is used to initialize a new event with a serial number
     and the <a>NDEFMessageInit</a> data via the <dfn>message</dfn> member.
-    If <dfn>serialNumber</dfn> is
-    [= dictionary member/not present =] or is `null`,
+    If <dfn>serialNumber</dfn> is not present or is `null`,
     empty string will be used to init the event.
   </p>
   <p class="note">
@@ -2212,7 +2211,7 @@
         denotes the string value which is used for matching the
         <a>record identifier</a> of each
         <a>NDEFRecord</a> object in an <a>NDEF message</a>.
-        If the dictionary member is [= dictionary member/not present =],
+        If the dictionary member is not present,
         then it will be ignored by the
         <a href="#steps-listen">NFC listen algorithm</a>.
       </p>
@@ -2221,7 +2220,7 @@
         denotes the string value which is used for matching the
         <a>record type</a> of each
         <a>NDEFRecord</a> object in an <a>NDEF message</a>.
-        If the dictionary member is [= dictionary member/not present =],
+        If the dictionary member is not present,
         then it will be ignored by the
         <a href="#steps-listen">NFC listen algorithm</a>.
       </p>


### PR DESCRIPTION
This PR fixes ReSpec issues below by simply removing `dictionary member/` as we already use blank `not present` in the spec.

![w3c github io_web-nfc_](https://user-images.githubusercontent.com/634478/77880332-b3f5a780-725c-11ea-8474-ed819f260dc5.png)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/pull/554.html" title="Last updated on Mar 30, 2020, 6:03 AM UTC (b8ffc0e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/554/edbad50...b8ffc0e.html" title="Last updated on Mar 30, 2020, 6:03 AM UTC (b8ffc0e)">Diff</a>