### PR TITLE
Fix #561: join NDEFReader and NDEFWriter

### DIFF
--- a/index.html
+++ b/index.html
@@ -943,12 +943,10 @@
   <section><h3>Feature support</h3>
     <p>
       Detecting if Web NFC is supported can be done by checking NDEFReader
-      and/or NDEFWriter objects. Note that this does not guarantee that NFC
-      hardware is available.
+      objects. Note that this does not guarantee that NFC hardware is available.
     </p>
     <pre class="example">
-      if ('NDEFReader' in window) { /* ... Scan NDEF Tags */ }
-      if ('NDEFWriter' in window) { /* ... Write NDEF Tags */ }
+      if ('NDEFReader' in window) { /* ... Scan and/or write NDEF Tags */ }
     </pre>
   </section>
 
@@ -957,8 +955,8 @@
       Writing a text string to an NFC tag is straightforward.
     </p>
     <pre class="example">
-      const writer = new NDEFWriter();
-      writer.write(
+      const ndef = new NDEFReader();
+      ndef.write(
         "Hello World"
       ).then(() => {
         console.log("Message written.");
@@ -973,8 +971,8 @@
       In order to write an NDEF record of URL type, simply use NDEFMessage.
     </p>
     <pre class="example">
-      const writer = new NDEFWriter();
-      writer.write({
+      const ndef = new NDEFReader();
+      ndef.write({
         records: [{ recordType: "url", data: "https://w3c.github.io/web-nfc/" }]
       }).then(() => {
         console.log("Message written.");
@@ -1013,15 +1011,14 @@
       a text message is written with the value "Hello World".
     </p>
     <pre class="example">
-      const reader = new NDEFReader();
-      await reader.scan();
-      reader.onreading = event => {
+      const ndef = new NDEFReader();
+      await ndef.scan();
+      ndef.onreading = event => {
         const message = event.message;
 
         if (message.records.length == 0 ||     // unformatted tag
             message.records[0].recordType == 'empty' ) {  // empty record
-          const writer = new NDEFWriter();
-          writer.write({
+          ndef.write({
             records: [{ recordType: "text", data: 'Hello World' }]
           });
           return;
@@ -1070,9 +1067,9 @@
       a write with a custom NDEF data layout.
     </p>
     <pre class="example">
-      const reader = new NDEFReader();
-      await reader.scan();
-      reader.onreading = async event => {
+      const ndef = new NDEFReader();
+      await ndef.scan();
+      ndef.onreading = async event => {
         if (event.message.id !== "my-game-progress")
           return;
 
@@ -1091,8 +1088,7 @@
             }))
           }]
         };
-        const writer = new NDEFWriter();
-        await writer.write(newMessage);
+        await ndef.write(newMessage);
         console.log("Message written");
       };
     </pre>
@@ -1103,9 +1099,9 @@
       Storing and receiving JSON data is easy with serialization and deserialization.
     </p>
     <pre class="example">
-      const reader = new NDEFReader();
-      await reader.scan();
-      reader.onreading = event => {
+      const ndef = new NDEFReader();
+      await ndef.scan();
+      ndef.onreading = event => {
         const decoder = new TextDecoder();
         for (const record of event.message.records) {
           if (record.mediaType === 'application/json') {
@@ -1116,9 +1112,8 @@
         }
       };
 
-      const writer = new NDEFWriter();
       const encoder = new TextEncoder();
-      writer.write({
+      ndef.write({
         records: [
           {
             recordType: "mime",
@@ -1147,10 +1142,10 @@
       property to `false`.
     </p>
     <pre class="example">
-      const reader = new NDEFReader();
-      reader.scan().then(() => {
+      const ndef = new NDEFReader();
+      ndef.scan().then(() => {
 
-        reader.onreading = event => {
+        ndef.onreading = event => {
           const decoder = new TextDecoder();
           for (const record of event.message.records) {
             console.log("Record type:  " + record.recordType);
@@ -1159,8 +1154,7 @@
           }
         };
 
-        const writer = new NDEFWriter();
-        return writer.write("Writing data is fun!", { ignoreRead: false });
+        return ndef.write("Writing data is fun!", { ignoreRead: false });
 
       }).catch(error => {
         console.log(`Write failed :-( try again: ${error}.`);
@@ -1192,9 +1186,9 @@
 
   <section> <h3>Write a smart poster message</h3>
     <pre class="example">
-      const writer = new NDEFWriter();
+      const ndef = new NDEFReader();
       const encoder = new TextEncoder();
-      writer.write({ records: [
+      ndef.write({ records: [
         {
           recordType: "smart-poster",  // Sp
           data: { records: [
@@ -1297,8 +1291,8 @@
       that may even contain an <a>NDEF message</a> as payload.
     </p>
     <pre class="example">
-      const writer = new NDEFWriter();
-      writer.write({ records: [
+      const ndef = new NDEFReader();
+      ndef.write({ records: [
         {
           recordType: "example.game:a",
           data: {
@@ -1331,8 +1325,8 @@
     </p>
     <pre class="example">
       const encoder = new TextEncoder();
-      const writer = new NDEFWriter();
-      writer.write({ records: [
+      const ndef = new NDEFReader();
+      ndef.write({ records: [
         {
           recordType: "example.com:shoppingItem", // External record
           data: {
@@ -1802,20 +1796,15 @@
 </section> <!-- Data types and content -->
 
 
-<section> <h2>The NDEFReader and NDEFWriter objects</h2>
-  The objects provide a way for the <a>browsing context</a> to
-  use NFC functionality.
-  They allow for writing <a>NDEF message</a>s to <a>NFC tag</a>s within range,
-  and to act on incoming <a>NDEF message</a>s from <a>NFC tag</a>s.
+<section> <h2>The NDEFReader object</h2>
+  <p>
+    The <dfn>NDEFReader</dfn> is an object that exposes NFC functionality to the
+    <a>browsing context</a>: reading data when a device, such as a tag, is within
+    the magnetic induction field. Also, it is used for writing
+    <a>NDEF message</a>s to <a>NFC tag</a>s within range.
+  </p>
   <pre class="idl">
     typedef (DOMString or BufferSource or NDEFMessageInit) NDEFMessageSource;
-
-    [SecureContext, Exposed=Window]
-    interface NDEFWriter {
-      constructor();
-
-      Promise&lt;void&gt; write(NDEFMessageSource message, optional NDEFWriteOptions options={});
-    };
 
     [SecureContext, Exposed=Window]
     interface NDEFReader : EventTarget {
@@ -1825,6 +1814,7 @@
       attribute EventHandler onreading;
 
       Promise&lt;void&gt; scan(optional NDEFScanOptions options={});
+      Promise&lt;void&gt; write(NDEFMessageSource message, optional NDEFWriteOptions options={});
     };
 
     [SecureContext, Exposed=Window]
@@ -1842,7 +1832,7 @@
   </pre>
   <p>
     The <dfn>NDEFMessageSource</dfn> is a union type representing argument types
-    accepted by the [=NDEFWriter/write()=] method.
+    accepted by the [=NDEFReader/write()=] method.
   </p>
   <p data-dfn-for="NDEFReadingEvent">
     The <dfn>NDEFReadingEvent</dfn> is the event being dispatched on new NFC readings.
@@ -1862,45 +1852,6 @@
     The serial number usually consists of 4 or 7 numbers, separated by `:`.
   </p>
   <p>
-    The <dfn>NDEFWriter</dfn> is an object used for writing data to an <a>NFC tag</a>.
-  </p>
-  <p>
-    An {{NDEFWriter}} object has the following <a data-cite=
-    "ECMASCRIPT#sec-object-internal-methods-and-internal-slots">
-    internal slots</a>:
-  </p>
-  <table class="simple">
-    <thead>
-     <tr>
-      <th>Internal Slot</th>
-      <th>Initial value</th>
-      <th>Description (<em>non-normative</em>)</th>
-     </tr>
-    </thead>
-    <tbody data-link-for="NDEFWriter">
-     <tr>
-      <td><dfn>[[\WriteOptions]]</dfn></td>
-      <td>`null`</td>
-      <td>
-        The {{NDEFWriteOptions}} value for writer.
-      </td>
-     </tr>
-     <tr>
-      <td><dfn>[[\WriteMessage]]</dfn></td>
-      <td>`null`</td>
-      <td>
-        The {{NDEFMessage}} to be written.
-        It is initially unset.
-      </td>
-     </tr>
-    </tbody>
-  </table>
-
-  <p>
-    The <dfn>NDEFReader</dfn> is an object used for reading data when a device,
-    such as a tag, is within the magnetic induction field.
-  </p>
-  <p>
     An {{NDEFReader}} object has the following <a data-cite=
     "ECMASCRIPT#sec-object-internal-methods-and-internal-slots">
     internal slots</a>:
@@ -1913,17 +1864,39 @@
       <th>Description (<em>non-normative</em>)</th>
      </tr>
     </thead>
-    <tbody data-link-for="NDEFScanOptions">
-      <tr>
-        <td><dfn>[[\Signal]]</dfn></td>
-        <td>`undefined`</td>
-        <td>
-          The {{NDEFScanOptions}}.<a>signal</a> to abort the operation.
-        </td>
-      </tr>
+    <tbody data-link-for="NDEFReader">
+     <tr>
+      <td><dfn>[[\ScanOptions]]</dfn></td>
+      <td>`null`</td>
+      <td>
+        The {{NDEFScanOptions}} value for reading.
+      </td>
+     </tr>
+     <tr>
+      <td><dfn>[[\ReadMessage]]</dfn></td>
+      <td>`null`</td>
+      <td>
+        The {{NDEFMessage}} that has been read.
+        It is initially unset.
+      </td>
+     </tr>
+     <tr>
+      <td><dfn>[[\WriteOptions]]</dfn></td>
+      <td>`null`</td>
+      <td>
+        The {{NDEFWriteOptions}} value for writing.
+      </td>
+     </tr>
+     <tr>
+      <td><dfn>[[\WriteMessage]]</dfn></td>
+      <td>`null`</td>
+      <td>
+        The {{NDEFMessage}} to be written.
+        It is initially unset.
+      </td>
+     </tr>
     </tbody>
   </table>
-
   <p>
     The <dfn data-dfn-for="NDEFReader">onreading</dfn> is an {{EventHandler}}
     which is called to notify that new reading is available.
@@ -1932,6 +1905,7 @@
     The <dfn data-dfn-for="NDEFReader">onerror</dfn> is an {{EventHandler}}
     which is called to notify that an error happened during reading.
   </p>
+
   <section><h3>NFC state associated with the settings object</h3>
   <p>
     The <a>relevant settings object</a> of the <a>active document</a> of a
@@ -1969,8 +1943,8 @@
       <td><dfn>[[\PendingWrite]]</dfn></td>
       <td>empty</td>
       <td>
-        A &lt;|promise:Promise|, |writer:NDEFWriter|&gt; tuple where |promise|
-        holds a pending {{Promise}} and |writer| holds an {{NDEFWriter}}.
+        A &lt;|promise:Promise|, |writer:NDEFReader|&gt; tuple where |promise|
+        holds a pending {{Promise}} and |writer| holds an {{NDEFReader}}.
       </td>
       </tr>
     </tbody>
@@ -2076,7 +2050,7 @@
     <p>
       The term <dfn id="nfc-suspended">suspended</dfn> refers to NFC
       operations being suspended, which means that no <a>NFC content</a> is
-      written by <a>NDEFWriter</a>s, and no received <a>NFC content</a> is
+      written by <a>NDEFReader</a>s, and no received <a>NFC content</a> is
       presented to any {{NDEFReader}} while being suspended.
     </p>
   </section>
@@ -2090,12 +2064,12 @@
         If there is no <a>pending write tuple</a> |tuple|, abort these steps.
       </li>
       <li>
-        If |tuple|'s writer has already initiated an ongoing NFC data transfer,
-        abort these steps.
+        If |tuple|'s  |writer:NDEFReader| has already initiated an ongoing NFC
+        data transfer, abort these steps.
       </li>
       <li>
-        Reject |tuple|'s promise with an {{"AbortError"}} {{DOMException}}
-        and abort these steps.
+        Reject |tuple|'s |promise:Promise| with an {{"AbortError"}}
+        {{DOMException}} and abort these steps.
         <p class=note>
           Rejecting the promise will clear the <a>pending write tuple</a>.
         </p>
@@ -2157,7 +2131,7 @@
     </p>
     <p>
       The <dfn>signal</dfn> property allows to abort
-      the [=NDEFWriter/write()=] operation.
+      the [=NDEFReader/write()=] operation.
     </p>
   </section>
 
@@ -2190,7 +2164,7 @@
     <section><h3>The <strong>write()</strong> method</h3>
       <div id="steps-write">
         The
-        <dfn>NDEFWriter.write</dfn> method, when invoked, MUST run the
+        <dfn>NDEFReader.write</dfn> method, when invoked, MUST run the
         <dfn>write a message</dfn> algorithm:
         <ol class=algorithm>
           <li>
@@ -2305,7 +2279,7 @@
 
       <div id="steps-start-nfc-write">
         To <dfn>start the NFC write</dfn>, run these steps:
-        <ol class=algorithm>
+        <ol class=algorithm data-link-for="NDEFWriteOptions">
           <li>
             Let |p:Promise| be the <a>pending write tuple</a>'s promise.
           </li>
@@ -2328,7 +2302,7 @@
             In case of success, run the following steps:
             <ol>
               <li>
-                If |device| is an <a>NFC tag</a> and if |options|'s overwrite is
+                If |device| is an <a>NFC tag</a> and if |options|'s <a>overwrite</a> is
                 `false`, read the tag to check whether there are <a>NDEF</a>
                 records on the tag. If yes, then reject |p| with a
                 {{"NotAllowedError"}} {{DOMException}} and return |p|.
@@ -2376,20 +2350,20 @@
     <div>
       To <dfn>create NDEF message</dfn> given a
       |source:NDEFMessageSource| and |context:string|, run these steps:
-      <ol class=algorithm id="create-web-nfc-message">
+      <ol class=algorithm id="create-web-nfc-message" data-link-for="NDEFMessageSource">
         <li>Switch on |source:NDEFMessageSource|'s type:
           <dl>
             <dt>{{DOMString}}</dt>
             <ul>
               <li>
-                Let |textRecord| be an <a>NDEFrecord</a> initialized with its
+                Let |textRecord| be an <a>NDEFRecord</a> initialized with its
                 |recordType| set to "`text`" and |data| set to |source|.
               </li>
               <li>
                 Let |records| be the list « |textRecord| ».
               </li>
               <li>
-                Set |source|'s records to |records|.
+                Set |source|'s  a>records</a> to |records|.
               </li>
             </ul>
             <dt>{{BufferSource}}</dt>
@@ -2403,13 +2377,13 @@
                   Let |records| be the list « |mimeRecord| ».
                 </li>
                 <li>
-                  Set |source|'s records to |records|.
+                  Set |source|'s  <a>records</a> to |records|.
                 </li>
             </ul>
             <dt>{{NDEFMessageInit}}</dt>
             <ul>
               <li>
-                If |source|'s records [= list/is empty =], [= exception/throw =]
+                If |source|'s <a>records</a> [= list/is empty =], [= exception/throw =]
                 a {{TypeError}} and abort these steps.
               </li>
             </ul>
@@ -2427,7 +2401,7 @@
         </li>
         <li>
           [= list/For each =] |record:NDEFRecordInit| in the <a>list</a>
-          |source|'s records, run the following steps:
+          |source|'s <a>records</a>, run the following steps:
           <ol>
             <li>
               Let |ndef| be the result of running <a>create NDEF record</a>
@@ -3304,19 +3278,20 @@
             <ol>
               <li>
                 If |key| equals "`signal`" and |value| is not `undefined`, set
-                |reader|.<a>[[\Signal]]</a> to |value|.
+                |reader|.<a>[[\ScanOptions]]</a>'s |signal:AbortSignal| to |value|.
               </li>
             </ol>
           </li>
           <li>
-            If |reader|.<a>[[\Signal]]</a>'s [= AbortSignal/aborted flag =] is
+            If |reader|.<a>[[\ScanOptions]]</a>'s |signal:AbortSignal|'s'
+            [= AbortSignal/aborted flag =] is
             set, then reject |p| with a {{"AbortError"}} {{DOMException}}
             and return |p|.
           </li>
           <li>
-            If |reader|.<a>[[\Signal]]</a> is not `null`, then
-            <a data-cite="dom#abortsignal-abort-algorithms">add the following
-            abort steps</a> to |reader|.<a>[[\Signal]]</a>:
+            If |reader|.<a>[[\ScanOptions]]</a>'s |signal:AbortSignal| is not
+             `null`, then <a data-cite="dom#abortsignal-abort-algorithms">
+             add the following abort steps</a> to |signal:AbortSignal|:
             <ol>
               <li>
                 Remove the {{NDEFReader}} instance from the


### PR DESCRIPTION
A first attempt to join NDEFReader and NDEFWriter into NDEFReader.

Updated the reader slot  `[[\Signal]]` to `[[\ScanOptions]]` like it's been with `NDEFWriter`.

Haven't touched yet `ignoreRead`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/web-nfc/pull/568.html" title="Last updated on Apr 30, 2020, 4:45 PM UTC (a8f2148)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/568/c6eaae2...zolkis:a8f2148.html" title="Last updated on Apr 30, 2020, 4:45 PM UTC (a8f2148)">Diff</a>