### PR TITLE
Update ReSpec header with new "group" option

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,9 @@
   'remove'></script>
   <script class="remove">
     var respecConfig = {
-      specStatus: "CG-DRAFT",
       shortName: "web-nfc",
+      group: "cg/web-nfc",
+      specStatus: "CG-DRAFT",
       editors: [
         {
           name: "Kenneth Rohde Christiansen",
@@ -54,8 +55,6 @@
         }
       ],
       testSuiteURI: "https://wpt.fyi/web-nfc/",
-      wg: "Web NFC Community Group",
-      wgURI: "https://www.w3.org/community/web-nfc/",
       github: "w3c/web-nfc",
       xref: "web-platform",
       localBiblio: {


### PR DESCRIPTION
This simple PR is about updating ReSpec header with new "group" config option to suppress ReSpec warning.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/pull/606.html" title="Last updated on Nov 19, 2020, 1:41 PM UTC (54e2800)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/606/23f6179...54e2800.html" title="Last updated on Nov 19, 2020, 1:41 PM UTC (54e2800)">Diff</a>