### PR TITLE
Fix CSS to improve spec readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,6 +131,7 @@
     table.simple { border: 1px solid #000; }
     table.simple td { border-right: 1px solid #000; }
     img.illustration { width: 100%; height: auto }
+    body { background-repeat: no-repeat !important; }
   </style>
 </head>
 


### PR DESCRIPTION
The W3C global CSS (https://github.com/w3c/tr-design)
used by W3C specs regressed and introduced a repeating
watermark all across the spec. This local workaround
removes that distraction and improves the spec
readability.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/pull/607.html" title="Last updated on Nov 19, 2020, 6:07 PM UTC (33f0bcf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/607/0315e56...33f0bcf.html" title="Last updated on Nov 19, 2020, 6:07 PM UTC (33f0bcf)">Diff</a>