### PR TITLE
Disallow explicitly non top-level browsing contexts

### DIFF
--- a/index.html
+++ b/index.html
@@ -2312,6 +2312,11 @@
             Let |p:Promise| be a new {{Promise}} object.
           </li>
           <li>
+            If not currently executing in the currently active <a>top-level
+            browsing context</a>, then reject |p| with and
+            {{"InvalidStateError"}} {{DOMException}} and return |p|.
+          </li>
+          <li>
             Let |message:NDEFMessageSource| be the first argument.
           </li>
           <li>
@@ -3408,6 +3413,11 @@
         <ol class=algorithm>
           <li>
             Let |p:Promise| be a new {{Promise}} object.
+          </li>
+          <li>
+            If not currently executing in the currently active <a>top-level
+            browsing context</a>, then reject |p| with and
+            {{"InvalidStateError"}} {{DOMException}} and return |p|.
           </li>
           <li>
             Let |reader:NDEFReader| be the {{NDEFReader}} instance.


### PR DESCRIPTION
Spec says Web NFC is allowed only in a top-level browsing context, but `scan` and `write` algorithm don't include those steps explicitly. This PR fixes this.

PTAL @zolkis


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/610.html" title="Last updated on Nov 25, 2020, 12:49 PM UTC (3142d03)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/610/8ae5979...beaufortfrancois:3142d03.html" title="Last updated on Nov 25, 2020, 12:49 PM UTC (3142d03)">Diff</a>