### PR TITLE
Fix #592: allow multiple readers but no multiple scans on any reader

### DIFF
--- a/index.html
+++ b/index.html
@@ -2204,8 +2204,8 @@
 
   <section><h3>Aborting pending write operation</h3>
   <div>
-    To attempt to <dfn>abort a pending write operation</dfn> on an
-    <a>environment settings object</a>, perform the following steps:
+    To attempt to <dfn>abort a pending write operation</dfn>,
+    run the following steps:
     <ol class=algorithm>
       <li>
         If there is no <a>pending write tuple</a> |tuple|, abort these steps.
@@ -2227,8 +2227,8 @@
 
   <section><h3>Aborting pending scan operation</h3>
   <div>
-    To attempt to <dfn>abort a pending scan operation</dfn> on an
-    <a>environment settings object</a>, perform the following steps:
+    To attempt to <dfn>abort a pending scan operation</dfn>,
+    run the following steps:
     <ol class=algorithm>
       <li>
         If there is no <a>pending read tuple</a> |tuple|, abort these steps.

--- a/index.html
+++ b/index.html
@@ -3437,11 +3437,17 @@
           </li>
           <li>
             If not currently executing in the currently active <a>top-level
-            browsing context</a>, then reject |p| with and
+            browsing context</a>, then reject |p| with an
             {{"InvalidStateError"}} {{DOMException}} and return |p|.
           </li>
           <li>
-            Attempt to <a>abort a pending scan operation</a>.
+            If there is a <a>pending read tuple</a> |tuple|, then reject |p|
+            with an {{"InvalidStateError"}} {{DOMException}} and return |p|.
+            <p class="note">
+              Note that scans need to be explicitly aborted before a new scan
+              could be done, and this behavior is different from writes, which
+              automatically abort and replace pending writes.
+            </p>
           </li>
           <li>
             Let |reader:NDEFReader| be the {{NDEFReader}} instance.

--- a/index.html
+++ b/index.html
@@ -2079,11 +2079,10 @@
       </td>
      </tr>
      <tr>
-      <td><dfn>[[\PendingRead]]</dfn></td>
+      <td><dfn>[[\ActivatedReaderList]]</dfn></td>
       <td>empty <a>set</a></td>
       <td>
-        A &lt;|promise:Promise|, |reader:NDEFReader|&gt; tuple where |promise|
-        holds a {{Promise}} and |reader| holds an {{NDEFReader}}.
+        A <a>set</a> of {{NDEFReader}} instances.
       </td>
      </tr>
      <tr>
@@ -2097,8 +2096,8 @@
     </tbody>
   </table>
   <p>
-    The <dfn>pending read tuple</dfn> is the value of the
-    <a>[[\PendingRead]]</a> internal slot.
+    The <dfn>activated reader objects</dfn> is the value of the
+    <a>[[\ActivatedReaderList]]</a> internal slot.
   </p>
   <p>
     The <dfn>pending write tuple</dfn> is the value of the
@@ -2225,31 +2224,6 @@
   </div>
   </section>
 
-  <section><h3>Aborting pending scan operation</h3>
-  <div>
-    To attempt to <dfn>abort a pending scan operation</dfn>,
-    run the following steps:
-    <ol class=algorithm>
-      <li>
-        If there is no <a>pending read tuple</a> |tuple|, abort these steps.
-      </li>
-      <li>
-        If |tuple|'s reader has already initiated an ongoing NFC data transfer,
-        abort these steps.
-      </li>
-      <li>
-        Reject |tuple|'s promise with an {{"InvalidStateError"}} {{DOMException}}.
-      </li>
-      <li>
-        Stop the <a>dispatch NFC content</a> steps.
-      </li>
-      <li>
-        Clear the <a>pending read tuple</a>.
-      </li>
-    </ol>
-  </div>
-  </section>
-
   <section><h3>Releasing NFC</h3>
   <p>
     To <dfn>release NFC</dfn> on an <a>environment settings object</a>,
@@ -2263,7 +2237,7 @@
       Attempt to <a>abort a pending write operation</a>.
     </li>
     <li>
-      Attempt to <a>abort a pending scan operation</a>.
+      Clear the <a>activated reader objects</a>.
     </li>
     <li>
       Release the NFC resources on the underlying platform.
@@ -3418,9 +3392,9 @@
       accessible to the client.
     </p>
     <p>
-      If there is a  <a>pending read tuple</a> whose |reader| is an
-      {{NDEFReader}} instance, then the <a>UA</a> MUST listen to
-      <a>NDEF message</a>s on all connected NFC adapters.
+      If there are any {{NDEFReader}} instances in <a>activated reader objects</a>
+      then the <a>UA</a> MUST listen to <a>NDEF message</a>s on all connected
+      NFC adapters.
     </p>
 
     <section> <h3>The <strong>scan()</strong> method</h3>
@@ -3441,15 +3415,6 @@
             {{"InvalidStateError"}} {{DOMException}} and return |p|.
           </li>
           <li>
-            If there is a <a>pending read tuple</a> |tuple|, then reject |p|
-            with an {{"InvalidStateError"}} {{DOMException}} and return |p|.
-            <p class="note">
-              Note that scans need to be explicitly aborted before a new scan
-              could be done, and this behavior is different from writes, which
-              automatically abort and replace pending writes.
-            </p>
-          </li>
-          <li>
             Let |reader:NDEFReader| be the {{NDEFReader}} instance.
           </li>
           <li>
@@ -3466,23 +3431,25 @@
           <li>
             If |signal| is not `null`, then
             <a data-cite="dom#abortsignal-abort-algorithms">
-            add the following abort steps</a> to |signal|:
-              <ol>
-                <li>
-                  Clear the <a>pending read tuple</a> .
-                </li>
-                <li>
-                  Make a request to stop listening to <a>NDEF message</a>s
-                  on all <a>NFC adapter</a>s.
-                </li>
-              </ol>
+            add the following <dfn>abort the pending scans</dfn> steps</a>
+            to |signal|:
+            <ol>
+              <li>
+                Remove |reader| from the <a>activated reader objects</a>.
+              </li>
+              <li>
+                If the <a>activated reader objects</a> [= list/is empty =],
+                then make a request to stop listening to <a>NDEF message</a>s
+                on all <a>NFC adapter</a>s.
+              </li>
+            </ol>
           </li>
           <li>
             [=promise/React=] to |p|:
             <ol>
               <li>
-                If |p| was settled (fulfilled or rejected), then clear the
-                <a>pending read tuple</a>.
+                If |p| was settled (fulfilled or rejected), then
+                <a>abort the pending scans</a>.
               </li>
             </ol>
           </li>
@@ -3507,7 +3474,7 @@
                 and abort these steps.
               </li>
               <li>
-                Set the <a>pending read tuple</a> to (|p|, |reader|).
+                Add |reader| to the <a>activated reader objects</a>.
               </li>
               <li>
                 Resolve |p|.
@@ -3532,10 +3499,14 @@
         If the <a>NFC tag</a> in proximity range does not expose <a>NDEF</a>
         technology for reading or formatting, run the following sub-steps:
         <ol>
-          <li>
-            If there is a <a>pending read tuple</a> whose |reader| is an
-            {{NDEFReader}} instance, fire an event</a> named "`readingerror`" at
-            |reader|.
+          <li>[= list/For each =]
+            {{NDEFReader}} instance |reader:NDEFReader| in the
+            <a>activated reader objects</a>, run the following sub-steps:
+            <ol>
+              <li>
+                <a>Fire an event</a> named "`error`" at |reader|.
+              </li>
+            </ol>
           </li>
           <li>
             Abort these steps.
@@ -3602,11 +3573,16 @@
     </p>
     <ol class=algorithm>
       <li>
-        If there is a <a>pending read tuple</a> whose |reader| is an
-        {{NDEFReader}} instance, <a>fire an event</a> named "`reading`" at
-        |reader| using <a>NDEFReadingEvent</a> with its <a>serialNumber</a>
-        attribute initialized to |serialNumber| and <a>message</a> attribute
-        initialized to |message|.
+        [= list/For each =] {{NDEFReader}} instance |reader:NDEFReader| in
+        the <a>activated reader objects</a>,
+        <ol>
+          <li>
+            <a>fire an event</a> named "`reading`" at |reader| using
+            <a>NDEFReadingEvent</a> with its <a>serialNumber</a> attribute
+            initialized to |serialNumber| and its <a>message</a> attribute
+            initialized to |message|.
+          </li>
+        </ol>
       </li>
     </ol>
     </section>

--- a/index.html
+++ b/index.html
@@ -3466,7 +3466,7 @@
               </li>
               <li>
                 If |reader| is already in the <a>activated reader objects</a>,
-                then reject |p| with a {{"InvalidStateError"}} {{DOMException}}
+                then reject |p| with an {{"InvalidStateError"}} {{DOMException}}
                 and abort these steps.
               </li>
               <li>

--- a/index.html
+++ b/index.html
@@ -2225,6 +2225,28 @@
   </div>
   </section>
 
+  <section><h3>Aborting pending scan operation</h3>
+  <div>
+    To attempt to <dfn>abort a pending scan operation</dfn> on an
+    <a>environment settings object</a>, perform the following steps:
+    <ol class=algorithm>
+      <li>
+        If there is no <a>pending read tuple</a> |tuple|, abort these steps.
+      </li>
+      <li>
+        If |tuple|'s reader has already initiated an ongoing NFC data transfer,
+        abort these steps.
+      </li>
+      <li>
+        Reject |tuple|'s promise with an {{"InvalidStateError"}} {{DOMException}}.
+      </li>
+      <li>
+        Clear the <a>pending read tuple</a> and abort these steps.
+      </li>
+    </ol>
+  </div>
+  </section>
+
   <section><h3>Releasing NFC</h3>
   <p>
     To <dfn>release NFC</dfn> on an <a>environment settings object</a>,
@@ -3418,6 +3440,9 @@
             If not currently executing in the currently active <a>top-level
             browsing context</a>, then reject |p| with and
             {{"InvalidStateError"}} {{DOMException}} and return |p|.
+          </li>
+          <li>
+            Attempt to <a>abort a pending scan operation</a>.
           </li>
           <li>
             Let |reader:NDEFReader| be the {{NDEFReader}} instance.

--- a/index.html
+++ b/index.html
@@ -2241,7 +2241,10 @@
         Reject |tuple|'s promise with an {{"InvalidStateError"}} {{DOMException}}.
       </li>
       <li>
-        Clear the <a>pending read tuple</a> and abort these steps.
+        Stop the <a>dispatch NFC content</a> steps.
+      </li>
+      <li>
+        Clear the <a>pending read tuple</a>.
       </li>
     </ol>
   </div>
@@ -2260,14 +2263,10 @@
       Attempt to <a>abort a pending write operation</a>.
     </li>
     <li>
-      Stop the <a>dispatch NFC content</a> steps.
+      Attempt to <a>abort a pending scan operation</a>.
     </li>
     <li>
-      Clear the <a>pending read tuple</a>.
-    </li>
-    <li>
-      Release the NFC resources associated with |nfc| on the
-      underlying platform.
+      Release the NFC resources on the underlying platform.
     </li>
   </ol>
   <p>

--- a/index.html
+++ b/index.html
@@ -3445,15 +3445,6 @@
             </ol>
           </li>
           <li>
-            [=promise/React=] to |p|:
-            <ol>
-              <li>
-                If |p| was settled (fulfilled or rejected), then
-                <a>clean up the pending scan</a>.
-              </li>
-            </ol>
-          </li>
-          <li>
             Return |p| and run the following steps <a>in parallel</a>:
             <ol>
               <li>

--- a/index.html
+++ b/index.html
@@ -3431,7 +3431,7 @@
           <li>
             If |signal| is not `null`, then
             <a data-cite="dom#abortsignal-abort-algorithms">
-            add the following <dfn>abort the pending scans</dfn> steps</a>
+            add the following <dfn>clean up the pending scan</dfn> steps</a>
             to |signal|:
             <ol>
               <li>
@@ -3449,7 +3449,7 @@
             <ol>
               <li>
                 If |p| was settled (fulfilled or rejected), then
-                <a>abort the pending scans</a>.
+                <a>clean up the pending scan</a>.
               </li>
             </ol>
           </li>
@@ -3471,6 +3471,11 @@
                 If the UA is not allowed to access the underlying <a>NFC Adapter</a>
                 (e.g. a user preference), then reject |p| with a
                 {{"NotReadableError"}} {{DOMException}}
+                and abort these steps.
+              </li>
+              <li>
+                If |reader| is already in the <a>activated reader objects</a>,
+                then reject |p| with a {{"InvalidStateError"}} {{DOMException}}
                 and abort these steps.
               </li>
               <li>

--- a/index.html
+++ b/index.html
@@ -2532,7 +2532,7 @@
                 Let |records| be the list « |textRecord| ».
               </li>
               <li>
-                Set |source|'s <a>records</a> to |records|.
+                Set |source|'s records to |records|.
               </li>
             </ul>
             <dt>{{BufferSource}}</dt>
@@ -2546,13 +2546,13 @@
                   Let |records| be the list « |mimeRecord| ».
                 </li>
                 <li>
-                  Set |source|'s <a>records</a> to |records|.
+                  Set |source|'s records to |records|.
                 </li>
             </ul>
             <dt>{{NDEFMessageInit}}</dt>
             <ul>
               <li>
-                If |source|'s <a>records</a> [= list/is empty =], [= exception/throw =]
+                If |source|'s records [= list/is empty =], [= exception/throw =]
                 a {{TypeError}} and abort these steps.
               </li>
             </ul>
@@ -2570,7 +2570,7 @@
         </li>
         <li>
           [= list/For each =] |record:NDEFRecordInit| in the <a>list</a>
-          |source|'s <a>records</a>, run the following steps:
+          |source|'s records, run the following steps:
           <ol>
             <li>
               Let |ndef| be the result of running <a>create NDEF record</a>


### PR DESCRIPTION
Signed-off-by: Zoltan Kis <zoltan.kis@intel.com>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/web-nfc/pull/611.html" title="Last updated on Dec 28, 2020, 9:11 AM UTC (341f824)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/611/0a0a609...zolkis:341f824.html" title="Last updated on Dec 28, 2020, 9:11 AM UTC (341f824)">Diff</a>