### PR TITLE
Remove redundant info

### DIFF
--- a/index.html
+++ b/index.html
@@ -3554,8 +3554,7 @@
         </ol>
       </li>
       <li>
-        If <a href="#nfc-is-suspended">NFC is not suspended</a>, run the
-        <a>dispatch NFC content</a> steps with given |serialNumber|
+        Run the <a>dispatch NFC content</a> steps with given |serialNumber|
         and |message|.
       </li>
     </ol>


### PR DESCRIPTION
Since the NFC reading algorithm starts with "If **NFC is suspended**, abort these steps.", we can omit this check again at the end when dispatching content. What do you think?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/pull/614.html" title="Last updated on Dec 31, 2020, 7:51 AM UTC (2663957)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/614/1f747e9...2663957.html" title="Last updated on Dec 31, 2020, 7:51 AM UTC (2663957)">Diff</a>