### PR TITLE
Throw SyntaxError if url is not valid for absolute-url records

### DIFF
--- a/index.html
+++ b/index.html
@@ -3025,7 +3025,7 @@
           </li>
           <li>
             If |url| is failure, [= exception/throw =] a
-            {{TypeError}} and abort these steps.
+            {{SyntaxError}} and abort these steps.
           </li>
           <li>
             Let |serializedURL:string| be


### PR DESCRIPTION
FIX https://github.com/w3c/web-nfc/issues/623


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/624.html" title="Last updated on Sep 22, 2021, 7:24 AM UTC (7f44d1e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/624/f912769...beaufortfrancois:7f44d1e.html" title="Last updated on Sep 22, 2021, 7:24 AM UTC (7f44d1e)">Diff</a>