### PR TITLE
Switch to HTML page visibility refs

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
   </style>
 </head>
 
-<body data-cite="MIMESNIFF SECURE-CONTEXTS PERMISSIONS ENCODING PAGE-VISIBILITY">
+<body data-cite="MIMESNIFF SECURE-CONTEXTS PERMISSIONS ENCODING">
 
 <!-- - - - - - - - - - - - - - - - Abstract - - - - - - - - - - - - - - - - -->
 <section id="abstract">
@@ -2167,7 +2167,7 @@
   <section><h3>Handling visibility change</h3>
     <p>
       When the user agent determines that the
-      <dfn data-cite="PAGE-VISIBILITY#dfn-visibility-states">visibility
+      <dfn data-cite="html#visibility-state">visibility
       state</dfn> of the [=environment settings object / responsible document=]
       of the <a>current settings object</a> changes, it must run these steps:
     </p>
@@ -4844,7 +4844,7 @@
       <p>
         Web NFC functionality is allowed only for the {{Document}} of the
         <a>top-level browsing context</a>, which must be
-        <dfn data-cite="PAGE-VISIBILITY#dom-visibilitystate-visible">visible</dfn>.
+        <dfn data-cite="html#visibility-state">visible</dfn>.
       </p>
       <p>
         This also means that UAs should block access to the NFC radio if

--- a/index.html
+++ b/index.html
@@ -885,7 +885,7 @@
     <p>
       Reading an <a>NFC tag</a> containing an <a>NDEF message</a>, while the
       {{Document}} of the <a>top-level browsing context</a> using Web NFC is
-      <a>visible</a>. For instance, a web page instructs the user to tap an NFC
+      visible. For instance, a web page instructs the user to tap an NFC
       tag, and then receives information from the tag.
     </p>
   </section>
@@ -2166,9 +2166,8 @@
 
   <section><h3>Handling visibility change</h3>
     <p>
-      When the user agent determines that the
-      <dfn data-cite="html#visibility-state">visibility
-      state</dfn> of the [=environment settings object / responsible document=]
+      When the user agent determines that the {{Document/visibilityState}}
+      of the [=environment settings object / responsible document=]
       of the <a>current settings object</a> changes, it must run these steps:
     </p>
     <ol class="algorithm">
@@ -2176,7 +2175,7 @@
       responsible document=] of the <a>current settings object</a>.
       </li>
       <li>
-        If |document|'s <a>visibility state</a> is `"visible"`,
+        If |document|'s {{Document/visibilityState}} is `"visible"`,
         <a>resume NFC</a> and abort these steps.
       </li>
       <li>
@@ -4843,8 +4842,8 @@
     <section> <h4>Visible document</h4>
       <p>
         Web NFC functionality is allowed only for the {{Document}} of the
-        <a>top-level browsing context</a>, which must be
-        <dfn data-cite="html#visibility-state">visible</dfn>.
+        <a>top-level browsing context</a>, where its 
+        {{Document/visibilityState}} is `"visible"`.
       </p>
       <p>
         This also means that UAs should block access to the NFC radio if

--- a/index.html
+++ b/index.html
@@ -2166,9 +2166,9 @@
 
   <section><h3>Handling visibility change</h3>
     <p>
-      When the user agent determines that the {{Document/visibilityState}}
+      When the user agent <a href="https://html.spec.whatwg.org/#update-the-visibility-state">updates the visibility state</a>
       of the [=environment settings object / responsible document=]
-      of the <a>current settings object</a> changes, it must run these steps:
+      of the <a>current settings object</a>, it must run these steps:
     </p>
     <ol class="algorithm">
       <li>Let |document:Document| be the [=environment settings object /


### PR DESCRIPTION
This PR is an attempt to address https://github.com/w3c/web-nfc/issues/626 as the Page Visibility spec is moving to the HTML spec.

@noamr What do you think?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/627.html" title="Last updated on Nov 5, 2021, 12:13 PM UTC (4616ff0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/627/760581a...beaufortfrancois:4616ff0.html" title="Last updated on Nov 5, 2021, 12:13 PM UTC (4616ff0)">Diff</a>