### PR TITLE
Fix 622 - constructors

### DIFF
--- a/index.html
+++ b/index.html
@@ -3647,10 +3647,18 @@
         the <a>activated reader objects</a>,
         <ol>
           <li>
-            <a>fire an event</a> named "`reading`" at |reader| using
-            <a>NDEFReadingEvent</a> with its <a>serialNumber</a> attribute
+            Let |init| be a [=new=] {{NDEFReadingEventInit}} dictionary,
+            with its <a>serialNumber</a> attribute
             initialized to |serialNumber| and its <a>message</a> attribute
             initialized to |message|.
+          </li>
+          <li>
+            Let |event| be a [=new=] {{NDEFReadingEvent}} given "`reading`"
+            and |init|.
+          </li>
+          <li>
+            <a>fire an event</a> named "`reading`" at |reader| using
+            |event|.
           </li>
         </ol>
       </li>

--- a/index.html
+++ b/index.html
@@ -2118,6 +2118,39 @@
     according to the algorithmic steps described in this specification.
   </section>
 
+  <section> <h3>The {{NDEFReadingEvent}} constructor</h3>
+    The {{NDEFReadingEvent}} constructor given |type| and |init| MUST perform
+    the following steps:
+    <ol class=algorithm>
+      <li>
+        Let |event| be the result of running the steps from
+        <a href="https://dom.spec.whatwg.org/#concept-event-constructor">
+        DOM Event constructor</a> given |type| and `null`.
+      </li>
+      <li>
+        Let |event|'s |serialNumber| be |init|'s |serialNumber|.
+        <p class="note">
+          The |serialNumber| is set by the <a>NFC reading algorithm</a>.
+        </p>
+      </li>
+      <li>
+        Let |event|'s |message| be |init|'s |message|.
+      </li>
+      <li>
+        Return |event|.
+      </li>
+    </ol>
+  </section>
+
+  <section> <h3>The {{NDEFReader}} constructor</h3>
+    The {{NDEFReader}} constructor given |type| and |init| MUST perform
+    the following steps:
+    <ol class=algorithm>
+      <li>
+      </li>
+    </ol>
+  </section>
+
   <section><h3>Obtaining permission</h3>
     <p>
       The

--- a/index.html
+++ b/index.html
@@ -1543,6 +1543,19 @@
       The <dfn>NDEFMessageInit</dfn> dictionary is used to initialize an
       <a>NDEF message</a>.
     </p>
+
+    <section> <h3>The {{NDEFMessage}} constructor</h3>
+      The <code>new NDEFMessage(init)</code> constructor steps are:
+      <ol class=algorithm>
+        <li>
+          Let [=this=] be the result of running the <a>create NDEF message</a> steps with |init:NDEFMessageSource|, `""` and `0`.
+          If this throws an exception, re-throw the exception and abort these steps.
+        </li>
+        <li>
+          Return [=this=].
+        </li>
+      </ol>
+    </section>
   </section>
 
   <section data-dfn-for="NDEFRecord"> <h3>The <dfn>NDEFRecord</dfn> interface</h3>
@@ -1677,7 +1690,6 @@
         {{"NotSupportedError"}} {{DOMException}} and abort these steps.
       </li>
     </ol>
-  </section> <!-- NDEFRecord dictionary -->
 
   <section>
     <h2>The <dfn>record type</dfn> string</h2>
@@ -1943,6 +1955,21 @@
     </tr>
   </table>
   </section>
+
+  <section> <h3>The {{NDEFRecord}} constructor</h3>
+    The <code>new NDEFRecord(init)</code> constructor steps are:
+    <ol class=algorithm>
+      <li>
+        Let [=this=] be the result of running the <a>create NDEF record</a> steps with |init|, `""` and `0`.
+        If this throws an exception, re-throw the exception and abort these steps.
+      </li>
+      <li>
+        Return [=this=].
+      </li>
+    </ol>
+  </section>
+</section> <!-- NDEFRecord -->
+
 </section> <!-- Data types and content -->
 
 
@@ -2118,35 +2145,43 @@
     according to the algorithmic steps described in this specification.
   </section>
 
-  <section> <h3>The {{NDEFReadingEvent}} constructor</h3>
-    The {{NDEFReadingEvent}} constructor given |type| and |init| MUST perform
-    the following steps:
+  <section> <h3>The {{NDEFReader}} constructor</h3>
+    The <code>new NDEFReader()</code> constructor steps are:
     <ol class=algorithm>
       <li>
-        Let |event| be the result of running the steps from
+        Initialize [=this=].{{NDEFReader/[[WriteOptions]]}} to `null`.
+      </li>
+      <li>
+        Initialize [=this=].{{NDEFReader/[[WriteMessage]]}} to `null`.
+      </li>
+      <li>
+        Return [=this=].
+      </li>
+    </ol>
+  </section>
+
+  <section> <h3>The {{NDEFReadingEvent}} constructor</h3>
+    The <code>new NDEFReadingEvent(type, init)</code> constructor steps are:
+    <ol class=algorithm>
+      <li>
+        Let [=this=] be the result of running the steps for
         <a href="https://dom.spec.whatwg.org/#concept-event-constructor">
         DOM Event constructor</a> given |type| and `null`.
       </li>
       <li>
-        Let |event|'s |serialNumber| be |init|'s |serialNumber|.
+        If that throws, re-throw the error and abort these steps.
+      </li>
+      <li>
+        Let [=this=].{{NDEFReadingEvent/serialNumber}} be |init|'s |serialNumber|.
         <p class="note">
           The |serialNumber| is set by the <a>NFC reading algorithm</a>.
         </p>
       </li>
       <li>
-        Let |event|'s |message| be |init|'s |message|.
+        Let [=this=].{{NDEFReadingEvent/message}} be |init|'s |message|.
       </li>
       <li>
-        Return |event|.
-      </li>
-    </ol>
-  </section>
-
-  <section> <h3>The {{NDEFReader}} constructor</h3>
-    The {{NDEFReader}} constructor given |type| and |init| MUST perform
-    the following steps:
-    <ol class=algorithm>
-      <li>
+        Return [=this=].
       </li>
     </ol>
   </section>
@@ -2298,7 +2333,7 @@
   <section data-dfn-for="NDEFScanOptions">
     <h3>The <dfn>NDEFScanOptions</dfn> dictionary</h3>
       <p>
-        To stop listening to NDEF messages, an [= AbortSignal/aborted flag =]
+        To stop listening to NDEF messages, an {{AbortSignal}}
         can be used in the <a>NDEFScanOptions</a> dictionary:
       </p>
       <pre class="idl">
@@ -2346,7 +2381,7 @@
             of the same name if present, or `null` otherwise.
           </li>
           <li>
-            If |signal|’s [= AbortSignal/aborted flag =] is set, then reject |p|
+            If |signal|’s {{AbortSignal}} is set, then reject |p|
             with an {{"AbortError"}} {{DOMException}} and return |p|.
           </li>
           <li>
@@ -3465,7 +3500,7 @@
             of the same name if present, or `null` otherwise.
           </li>
           <li>
-            If |signal|’s [= AbortSignal/aborted flag =] is set, then reject |p|
+            If |signal|’s {{AbortSignal}} is set, then reject |p|
             with an {{"AbortError"}} {{DOMException}} and return |p|.
           </li>
           <li>


### PR DESCRIPTION
Addresses the main concerns from #622, some concerns need more discussion.
Adds constructors, as sub-sections.
Fixes AbortSignal citations.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/zolkis/web-nfc/pull/628.html" title="Last updated on Nov 16, 2021, 4:17 PM UTC (1ac631b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/628/760581a...zolkis:1ac631b.html" title="Last updated on Nov 16, 2021, 4:17 PM UTC (1ac631b)">Diff</a>