### PR TITLE
Add type NDEFRecordType to web-nfc.d.ts

### DIFF
--- a/web-nfc.d.ts
+++ b/web-nfc.d.ts
@@ -22,9 +22,11 @@ declare type NDEFRecordDataSource = string | BufferSource | NDEFMessageInit
 interface Window {
   NDEFRecord: NDEFRecord
 }
+type NDEFRecordTypes = "absolute-url" | "empty" | "mime" | "smart-poster" | "text" | "unknown" | "URL";
+
 declare class NDEFRecord {
   constructor(recordInit: NDEFRecordInit)
-  readonly recordType: string
+  readonly recordType: NDEFRecordTypes
   readonly mediaType?: string
   readonly id?: string
   readonly data?: DataView
@@ -33,7 +35,7 @@ declare class NDEFRecord {
   toRecords?: () => NDEFRecord[]
 }
 declare interface NDEFRecordInit {
-  recordType: string
+  recordType: NDEFRecordTypes
   mediaType?: string
   id?: string
   encoding?: string

--- a/web-nfc.d.ts
+++ b/web-nfc.d.ts
@@ -22,7 +22,7 @@ declare type NDEFRecordDataSource = string | BufferSource | NDEFMessageInit
 interface Window {
   NDEFRecord: NDEFRecord
 }
-type NDEFRecordTypes = string | "absolute-url" | "empty" | "mime" | "smart-poster" | "text" | "unknown" | "URL";
+type NDEFRecordTypes = string | "absolute-url" | "empty" | "mime" | "smart-poster" | "text" | "unknown" | "url";
 
 declare class NDEFRecord {
   constructor(recordInit: NDEFRecordInit)

--- a/web-nfc.d.ts
+++ b/web-nfc.d.ts
@@ -22,7 +22,7 @@ declare type NDEFRecordDataSource = string | BufferSource | NDEFMessageInit
 interface Window {
   NDEFRecord: NDEFRecord
 }
-type NDEFRecordTypes = "absolute-url" | "empty" | "mime" | "smart-poster" | "text" | "unknown" | "URL";
+type NDEFRecordTypes = string | "absolute-url" | "empty" | "mime" | "smart-poster" | "text" | "unknown" | "URL";
 
 declare class NDEFRecord {
   constructor(recordInit: NDEFRecordInit)

--- a/web-nfc.d.ts
+++ b/web-nfc.d.ts
@@ -22,7 +22,7 @@ declare type NDEFRecordDataSource = string | BufferSource | NDEFMessageInit
 interface Window {
   NDEFRecord: NDEFRecord
 }
-type NDEFRecordTypes = string | "absolute-url" | "empty" | "mime" | "smart-poster" | "text" | "unknown" | "url";
+declare type NDEFRecordTypes = "absolute-url" | "empty" | "mime" | "smart-poster" | "text" | "unknown" | "url";
 
 declare class NDEFRecord {
   constructor(recordInit: NDEFRecordInit)


### PR DESCRIPTION
This pull request is for adding types to recordTypes.
- It adds a new type: "NDEFRecordTypes"
- It includes all valid record types for recordTypes referenced from https://developer.mozilla.org/en-US/docs/Web/API/NDEFReader/write
- Values consist of: 
   "absolute-url"
   "empty"
   "mime"
   "smart-poster"
   "text"
   "unknown"
   "URL"