### PR TITLE
Update "aborted flag" references and use "abort reason" instead

### DIFF
--- a/index.html
+++ b/index.html
@@ -2263,10 +2263,6 @@
 
   <section data-dfn-for="NDEFScanOptions">
     <h3>The <dfn>NDEFScanOptions</dfn> dictionary</h3>
-      <p>
-        To stop listening to NDEF messages, an [= AbortSignal/aborted flag =]
-        can be used in the <a>NDEFScanOptions</a> dictionary:
-      </p>
       <pre class="idl">
         dictionary NDEFScanOptions {
           AbortSignal signal;
@@ -2312,8 +2308,8 @@
             of the same name if present, or `null` otherwise.
           </li>
           <li>
-            If |signal|’s [= AbortSignal/aborted flag =] is set, then reject |p|
-            with an {{"AbortError"}} {{DOMException}} and return |p|.
+            If |signal| is [= AbortSignal/aborted =], then reject |p|
+            with |signal|'s [=AbortSignal/abort reason=] and return |p|.
           </li>
           <li>
             If |signal| is not `null`, then
@@ -3431,8 +3427,8 @@
             of the same name if present, or `null` otherwise.
           </li>
           <li>
-            If |signal|’s [= AbortSignal/aborted flag =] is set, then reject |p|
-            with an {{"AbortError"}} {{DOMException}} and return |p|.
+            If |signal| is [= AbortSignal/aborted =], then reject |p|
+            with |signal|'s [=AbortSignal/abort reason=] and return |p|.
           </li>
           <li>
             If |signal| is not `null`, then


### PR DESCRIPTION
FIX https://github.com/w3c/web-nfc/issues/630


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/631.html" title="Last updated on Nov 24, 2021, 8:03 AM UTC (e98e276)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/631/b71177e...beaufortfrancois:e98e276.html" title="Last updated on Nov 24, 2021, 8:03 AM UTC (e98e276)">Diff</a>