### PR TITLE
Add missing aborting pending make read-only operations

### DIFF
--- a/index.html
+++ b/index.html
@@ -2243,8 +2243,18 @@
         <a>resume NFC</a> and abort these steps.
       </li>
       <li>
-        Otherwise, <a>suspend NFC</a> and attempt to <a>abort a pending
-        write operation</a>.
+        Otherwise, perform these steps:
+        <ol>
+          <li>
+            <a>Suspend NFC</a>.
+          </li>
+          <li>
+            Attempt to <a>abort a pending write operation</a>.
+          </li>
+          <li>
+            Attempt to <a>abort a pending make read-only operation</a>.
+          </li>
+        </ol>
       </li>
     </ol>
     <p>
@@ -2312,6 +2322,9 @@
     </li>
     <li>
       Attempt to <a>abort a pending write operation</a>.
+    </li>
+    <li>
+      Attempt to <a>abort a pending make read-only operation</a>.
     </li>
     <li>
       Clear the <a>activated reader objects</a>.


### PR DESCRIPTION
I realized I've missed some "abort pending make read-only operation" in my last [PR](https://github.com/w3c/web-nfc/pull/632) when adding `makeReadOnly()` to NDEFReader. This PR fixes it.

@kenchris @zolkis Please have a look.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/web-nfc/pull/633.html" title="Last updated on Dec 8, 2021, 8:32 AM UTC (f653f7c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/633/8cddbcf...beaufortfrancois:f653f7c.html" title="Last updated on Dec 8, 2021, 8:32 AM UTC (f653f7c)">Diff</a>