### PR TITLE
Add makeReadOnly to TypeScript definitions

### DIFF
--- a/web-nfc.d.ts
+++ b/web-nfc.d.ts
@@ -55,6 +55,7 @@ declare class NDEFReader extends EventTarget {
     message: NDEFMessageSource,
     options?: NDEFWriteOptions
   ) => Promise<void>
+  makeReadOnly: (options?: NDEFMakeReadOnlyOptions) => Promise<void>
 }
 
 interface Window {
@@ -72,6 +73,9 @@ interface NDEFReadingEventInit extends EventInit {
 
 interface NDEFWriteOptions {
   overwrite?: boolean
+  signal?: AbortSignal
+}
+interface NDEFMakeReadOnlyOptions {
   signal?: AbortSignal
 }
 interface NDEFScanOptions {


### PR DESCRIPTION
Following spec changes around the new `makeReadOnly` method in NDEFReader, this PR updates the TypeScript definitions.