### PR TITLE
Editorial: don't show W3C logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,14 +38,6 @@
       ],
       logos: [
         {
-          src: 'images/w3c-logo.svg',
-          url: "https://w3.org",
-          alt: "W3C logo",
-          width: 95,
-          height: 68,
-          id: 'w3c-logo'
-        },
-        {
           src: 'images/webnfc-logo.svg',
           url: "https://w3c.github.io/web-nfc/",
           alt: "Web NFC logo",


### PR DESCRIPTION
Sorry, only Working Group specs can show the W3C logo 😢. This is to avoid confusion with things on the standards track. The other logo is fine tho.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 16, 2022, 2:16 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fweb-nfc%2Fb1855fc6ca3489375484d5dc87271d8f9b3852e0%2Findex.html%3FisPreview%3Dtrue)

```
📡 HTTP Error 429: https://rawcdn.githack.com/w3c/web-nfc/b1855fc6ca3489375484d5dc87271d8f9b3852e0/index.html
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/web-nfc%23637.)._
</details>
