### PR TITLE
Proper document access in page visibility change steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -2214,7 +2214,7 @@
 
   <section><h3>Handling visibility change</h3>
     <p>
-      The <a href="https://html.spec.whatwg.org/#page-visibility-change-steps">page visibility change steps</a> for this specification, given |visibilityState| and |document|, are:
+    The [=page visibility change steps=] for this specification, given the string |visibilityState| and the {{Document}} |document|, are:
     </p>
     <ol class="algorithm">
       <li>

--- a/index.html
+++ b/index.html
@@ -2214,17 +2214,11 @@
 
   <section><h3>Handling visibility change</h3>
     <p>
-      When the user agent <a href="https://html.spec.whatwg.org/#update-the-visibility-state">updates the visibility state</a>
-      of the <a>current settings object</a>'s <a>relevant global object</a>'s
-      <a>associated <code>Document</code></a> it must run these steps:
+      The <a href="https://html.spec.whatwg.org/#page-visibility-change-steps">page visibility change steps</a> for this specification, given |visibilityState| and |document|, are:
     </p>
     <ol class="algorithm">
       <li>
-        Let |document:Document| be the <a>associated <code>Document</code></a>
-        of the <a>current settings object</a>'s <a>relevant global object</a>.
-      </li>
-      <li>
-        If |document|'s {{Document/visibilityState}} is `"visible"`,
+        If |visibilityState| is `"visible"`,
         <a>resume NFC</a> and abort these steps.
       </li>
       <li>


### PR DESCRIPTION
As I learned from @Domenic, "relevant global object" cannot be used on
"current settings object", only on platform objects
(https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global)

Luckily, the HTML spec already passes visibilityState and document to
other specifications running page visibility change steps. So we can
just use those directly here.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johannhof/web-nfc/pull/641.html" title="Last updated on Mar 29, 2022, 11:47 AM UTC (a06a7bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/641/75fc0bf...johannhof:a06a7bd.html" title="Last updated on Mar 29, 2022, 11:47 AM UTC (a06a7bd)">Diff</a>