### PR TITLE
Drop link to potentially malicious example.com web site

### DIFF
--- a/index.html
+++ b/index.html
@@ -4782,8 +4782,8 @@
       do so by cloning the data of the original tag and modifying it -
       either by changing the URL to load a malicious app/site, or by
       changing the data to inject malicious data in the right app/site.
-      Example: the tag is supposed to take you to <a href="https://example.com">https://example.com</a> but is modified
-      to take you to <a href="https://exаmple.com">https://exаmple.com</a> (that is with a Cyrillic а) - it looks legitimate
+      Example: the tag is supposed to take you to <code>https://example.com</code> but is modified
+      to take you to <code>https://exаmple.com</code> (that is with a Cyrillic а) - it looks legitimate
       and you might now to giving sensitive data to a malicious site.
     </p>
     <p>


### PR DESCRIPTION
It is a very good idea to illustrate the malicious use case with a concrete example. It does not seem to be such a good idea to link to an external web site which could exist in theory, and could well be malicious if it existed.

For consistency, this update also drops the link to the legitimate example.com URL although this link could remain as there are strong guarantees that this site will always exist for illustrative examples.

To illustrate what happens more clearly, it could perhaps be worthwhile to represent the Punnycode representation of the potentially malicious URL: `https://xn--exmple-4nf.com/`. Happy to update the PR with that in mind if you think that's useful.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/web-nfc/pull/649.html" title="Last updated on Sep 21, 2022, 10:35 AM UTC (fb9aa90)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/649/c252a8f...tidoust:fb9aa90.html" title="Last updated on Sep 21, 2022, 10:35 AM UTC (fb9aa90)">Diff</a>