### PR TITLE
Fix links to informative references

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,13 +51,13 @@
       xref: "web-platform",
       localBiblio: {
         "NFC-SECURITY": {
-          href: "https://github.com/w3c/web-nfc/security-privacy.html",
+          href: "https://w3c.github.io/web-nfc/archive/security-privacy.html",
           title: "Web NFC Security and Privacy",
           publisher: "W3C",
           date: "25 April 2015",
         },
         "NFC-USECASES": {
-          href: "https://github.com/w3c/web-nfc/use-cases.html",
+          href: "https://w3c.github.io/web-nfc/use-cases.html",
           title: "Web NFC Use Cases",
           publisher: "W3C",
           date: "25 April 2015",


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/pull/656.html" title="Last updated on Nov 14, 2023, 1:54 PM UTC (82435fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/656/ee6de1c...82435fe.html" title="Last updated on Nov 14, 2023, 1:54 PM UTC (82435fe)">Diff</a>