### PR TITLE
Issue-669: Section 9.15.3 remove incorrect reference to MB Field

### DIFF
--- a/index.html
+++ b/index.html
@@ -4143,7 +4143,7 @@
         Set |record|'s <a>lang</a> to |language|.
       </li>
       <li>
-        Set |record|'s <a>encoding</a> be "`utf-8`" if bit `7` ([=MB field=]) of
+        Set |record|'s <a>encoding</a> be "`utf-8`" if bit `7` of
         |header| is equal to the value `0`, or else "`utf-16be`".
       </li>
       <li>


### PR DESCRIPTION
This removes the reference to the MB Field in section 9.15.3 when parsing the well-known text field `header`


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/johntalton/web-nfc/pull/671.html" title="Last updated on Aug 18, 2025, 9:36 AM UTC (cce93fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/web-nfc/671/3d4997a...johntalton:cce93fb.html" title="Last updated on Aug 18, 2025, 9:36 AM UTC (cce93fb)">Diff</a>